### PR TITLE
Handle missing CONF_ENABLE_PARAMETER_CONFIGURATION

### DIFF
--- a/number.py
+++ b/number.py
@@ -96,7 +96,7 @@ async def async_setup_entry(
 ) -> None:
     """Huawei Solar Number entities Setup."""
 
-    if not entry.data[CONF_ENABLE_PARAMETER_CONFIGURATION]:
+    if not entry.data.get(CONF_ENABLE_PARAMETER_CONFIGURATION):
         _LOGGER.info("Skipping number setup, as parameter configuration is not enabled")
         return
 


### PR DESCRIPTION
Don't throw exception if CONF_ENABLE_PARAMETER_CONFIGURATION is not set in configuration entry.