### PR TITLE
Update manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -8,5 +8,5 @@
     "codeowners": ["@wlcrs"],
     "iot_class": "local_polling",
     "version": "1.2.6b8",
-    "loggers": ["huawei_solar", "pymodbus"],
+    "loggers": ["huawei_solar", "pymodbus"]
 }


### PR DESCRIPTION
Error 
2023-07-17 10:17:25.758 ERROR (SyncWorker_0) [homeassistant.loader] Error parsing manifest.json file at /config/custom_components/huawei_solar/manifest.json: trailing comma is not allowed: line 11 column 44 (char 414)