### PR TITLE
Update manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "domain": "huawei_solar",
     "name": "Huawei Solar",
     "config_flow": true,
-    "documentation": "https://www.home-assistant.io/integrations/huawei_solar",
+    "documentation": "https://github.com/wlcrs/huawei_solar/wiki",
     "issue_tracker": "https://github.com/wlcrs/huawei_solar/issues",
     "requirements": ["huawei-solar==2.2.8b2"],
     "codeowners": ["@wlcrs"],


### PR DESCRIPTION
huawei_solar integration doesn't exist in home assistant, so the link should navigate to the wiki.
The current link (https://www.home-assistant.io/integrations/huawei_solar) navigates to a page that doesn't exist.