### PR TITLE
Configuration options to exclude selected devices from config entry

### DIFF
--- a/const.py
+++ b/const.py
@@ -10,7 +10,9 @@ DEFAULT_PASSWORD = "00000a"
 
 CONF_SLAVE_IDS = "slave_ids"
 CONF_ENABLE_PARAMETER_CONFIGURATION = "enable_parameter_configuration"
-
+CONF_EXCLUDE_BATTERY = "exclude_battery"
+CONF_EXCLUDE_OPTIMIZERS = "exclude_optimizers"
+CONF_EXCLUDE_POWER_METER = "exclude_power_meter"
 
 DATA_BRIDGES_WITH_DEVICEINFOS = "bridges"
 DATA_UPDATE_COORDINATORS = "update_coordinators"

--- a/sensor.py
+++ b/sensor.py
@@ -39,6 +39,8 @@ from . import (
     HuaweiSolarUpdateCoordinator,
 )
 from .const import (
+    CONF_EXCLUDE_BATTERY,
+    CONF_EXCLUDE_POWER_METER,
     DATA_CONFIGURATION_UPDATE_COORDINATORS,
     DATA_OPTIMIZER_UPDATE_COORDINATORS,
     DATA_UPDATE_COORDINATORS,
@@ -659,26 +661,30 @@ async def async_setup_entry(
                     )
                 )
 
-        if bridge.power_meter_type == rv.MeterType.SINGLE_PHASE:
-            for entity_description in SINGLE_PHASE_METER_ENTITY_DESCRIPTIONS:
-                slave_entities.append(
-                    HuaweiSolarSensorEntity(
-                        update_coordinator,
-                        entity_description,
-                        device_infos["power_meter"],
+        if not entry.data.get(CONF_EXCLUDE_POWER_METER):
+            if bridge.power_meter_type == rv.MeterType.SINGLE_PHASE:
+                for entity_description in SINGLE_PHASE_METER_ENTITY_DESCRIPTIONS:
+                    slave_entities.append(
+                        HuaweiSolarSensorEntity(
+                            update_coordinator,
+                            entity_description,
+                            device_infos["power_meter"],
+                        )
                     )
-                )
-        elif bridge.power_meter_type == rv.MeterType.THREE_PHASE:
-            for entity_description in THREE_PHASE_METER_ENTITY_DESCRIPTIONS:
-                slave_entities.append(
-                    HuaweiSolarSensorEntity(
-                        update_coordinator,
-                        entity_description,
-                        device_infos["power_meter"],
+            elif bridge.power_meter_type == rv.MeterType.THREE_PHASE:
+                for entity_description in THREE_PHASE_METER_ENTITY_DESCRIPTIONS:
+                    slave_entities.append(
+                        HuaweiSolarSensorEntity(
+                            update_coordinator,
+                            entity_description,
+                            device_infos["power_meter"],
+                        )
                     )
-                )
 
-        if bridge.battery_type != rv.StorageProductModel.NONE:
+        if (
+            not entry.data.get(CONF_EXCLUDE_BATTERY)
+            and bridge.battery_type != rv.StorageProductModel.NONE
+        ):
             for entity_description in BATTERY_SENSOR_DESCRIPTIONS:
                 slave_entities.append(
                     HuaweiSolarSensorEntity(

--- a/strings.json
+++ b/strings.json
@@ -40,6 +40,15 @@
                 },
                 "title": "Path"
             },
+            "exclusions": {
+                "data": {
+                    "exclude_battery": "Exclude battery",
+                    "exclude_optimizers": "Exclude optmizers",
+                    "exclude_power_meter": "Exclude power meter"
+                },
+                "title": "Excluded devices",
+                "description": "The selected devices will not be added to the configuration"
+            },
             "user": {
                 "data": {
                     "type": "Connection type"

--- a/translations/en.json
+++ b/translations/en.json
@@ -40,6 +40,15 @@
                 },
                 "title": "Path"
             },
+            "exclusions": {
+                "data": {
+                    "exclude_battery": "Exclude battery",
+                    "exclude_optimizers": "Exclude optmizers",
+                    "exclude_power_meter": "Exclude power meter"
+                },
+                "title": "Excluded devices",
+                "description": "The selected devices will not be added to the configuration"
+            },
             "user": {
                 "data": {
                     "type": "Connection type"


### PR DESCRIPTION
This PR introduces an additional step in the integration configuration flow, allowing the user to select devices to be excluded from the configuration. The options include: battery, power meter, and optimizers.

Excluding any of these devices means that the integration will not create entities for them. At a bare minimum, only the inverter is created.

This is especially useful for optimizers, as there are usually many, and if not used, they just cause pollution and significant startup delays in HA.