### PR TITLE
add requirements pymodbus<=3.6.5

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,8 @@
     "documentation": "https://github.com/wlcrs/huawei_solar/wiki",
     "issue_tracker": "https://github.com/wlcrs/huawei_solar/issues",
     "requirements": [
-        "huawei-solar==2.2.9"
+        "huawei-solar==2.2.9",
+        "pymodbus<=3.6.5"
     ],
     "codeowners": [
         "@wlcrs"


### PR DESCRIPTION
Huawei_solar currently supports maxiamal pymodbus version 3.6.5. If another integration bump a newer version of pymodbus, then huawei_solar will no longer work. This has currently happened in connection with the integration [homeassistant-solax-modbus](https://github.com/wills106/homeassistant-solax-modbus).