### PR TITLE
Change unit of insulation resistance to MOhm

### DIFF
--- a/sensor.py
+++ b/sensor.py
@@ -186,7 +186,7 @@ INVERTER_SENSOR_DESCRIPTIONS: tuple[HuaweiSolarSensorEntityDescription, ...] = (
     HuaweiSolarSensorEntityDescription(
         key=rn.INSULATION_RESISTANCE,
         icon="mdi:omega",
-        native_unit_of_measurement="ohm",
+        native_unit_of_measurement="MOhm",
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
     ),


### PR DESCRIPTION
Thanks for making this entity available in v1.4.0!

The unit of insulation resistance as reported by the inverter is MOhm (as shown in FusionSolar) and not Ohm. Theoretically one could also set the `native_unit_of_measurement` to `MΩ`, but I'm not entirely sure if this breaks something in HA.