### PR TITLE
prevent entity id translation

### DIFF
--- a/number.py
+++ b/number.py
@@ -9,6 +9,7 @@ from homeassistant.components.number import (
     NumberEntity,
     NumberEntityDescription,
     NumberMode,
+    ENTITY_ID_FORMAT,
 )
 from homeassistant.components.number.const import DEFAULT_MAX_VALUE, DEFAULT_MIN_VALUE
 from homeassistant.config_entries import ConfigEntry
@@ -257,6 +258,7 @@ class HuaweiSolarNumberEntity(CoordinatorEntity, HuaweiSolarEntity, NumberEntity
 
         self._attr_device_info = device_info
         self._attr_unique_id = f"{bridge.serial_number}_{description.key}"
+        self.entity_id = ENTITY_ID_FORMAT.format(f"{DOMAIN.lower()}_{self._attr_unique_id.lower()}")
 
         self._static_max_value = static_max_value
         self._static_min_value = static_min_value

--- a/select.py
+++ b/select.py
@@ -8,7 +8,7 @@ from enum import IntEnum
 import logging
 from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast
 
-from homeassistant.components.select import SelectEntity, SelectEntityDescription
+from homeassistant.components.select import SelectEntity, SelectEntityDescription, ENTITY_ID_FORMAT
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
@@ -174,6 +174,7 @@ class HuaweiSolarSelectEntity(CoordinatorEntity, HuaweiSolarEntity, SelectEntity
 
         self._attr_device_info = device_info
         self._attr_unique_id = f"{bridge.serial_number}_{description.key}"
+        self.entity_id = ENTITY_ID_FORMAT.format(f"{DOMAIN.lower()}_{self._attr_unique_id.lower()}")
 
         self._register_unit: IntEnum = cast(
             r.NumberRegister, REGISTERS[description.key]
@@ -264,6 +265,7 @@ class StorageModeSelectEntity(CoordinatorEntity, HuaweiSolarEntity, SelectEntity
         )
         self._attr_device_info = device_info
         self._attr_unique_id = f"{bridge.serial_number}_{self.entity_description.key}"
+        self.entity_id = ENTITY_ID_FORMAT.format(f"{DOMAIN.lower()}_{self._attr_unique_id.lower()}")
 
         self._attr_current_option = None
         # The options depend on the type of battery

--- a/sensor.py
+++ b/sensor.py
@@ -11,6 +11,7 @@ from homeassistant.components.sensor import (
     SensorEntity,
     SensorEntityDescription,
     SensorStateClass,
+    ENTITY_ID_FORMAT,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
@@ -959,6 +960,7 @@ class HuaweiSolarSensorEntity(CoordinatorEntity, HuaweiSolarEntity, SensorEntity
 
         self._attr_device_info = device_info
         self._attr_unique_id = f"{coordinator.bridge.serial_number}_{description.key}"
+        self.entity_id = ENTITY_ID_FORMAT.format(f"{DOMAIN.lower()}_{self._attr_unique_id.lower()}")
 
         self._register_key = self.entity_description.key
         if "#" in self._register_key:
@@ -1081,6 +1083,7 @@ class HuaweiSolarTOUPricePeriodsSensorEntity(
         self._bridge = bridge
         self._attr_device_info = device_info
         self._attr_unique_id = f"{bridge.serial_number}_{self.entity_description.key}"
+        self.entity_id = ENTITY_ID_FORMAT.format(f"{DOMAIN.lower()}_{self._attr_unique_id.lower()}")
 
     def _lg_resu_period_to_text(self, period: LG_RESU_TimeOfUsePeriod):
         return (
@@ -1160,6 +1163,7 @@ class HuaweiSolarCapacityControlPeriodsSensorEntity(
         self._bridge = bridge
         self._attr_device_info = device_info
         self._attr_unique_id = f"{bridge.serial_number}_{self.entity_description.key}"
+        self.entity_id = ENTITY_ID_FORMAT.format(f"{DOMAIN.lower()}_{self._attr_unique_id.lower()}")
 
     def _period_to_text(self, psp: PeakSettingPeriod):
         return (
@@ -1224,6 +1228,7 @@ class HuaweiSolarFixedChargingPeriodsSensorEntity(
         self._bridge = bridge
         self._attr_device_info = device_info
         self._attr_unique_id = f"{bridge.serial_number}_{self.entity_description.key}"
+        self.entity_id = ENTITY_ID_FORMAT.format(f"{DOMAIN.lower()}_{self._attr_unique_id.lower()}")
 
     def _period_to_text(self, cdp: ChargeDischargePeriod):
         return (
@@ -1292,6 +1297,7 @@ class HuaweiSolarForcibleChargeEntity(
         self._bridge = bridge
         self._attr_device_info = device_info
         self._attr_unique_id = f"{bridge.serial_number}_{self.entity_description.key}"
+        self.entity_id = ENTITY_ID_FORMAT.format(f"{DOMAIN.lower()}_{self._attr_unique_id.lower()}")
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -1383,6 +1389,7 @@ class HuaweiSolarActivePowerControlModeEntity(
         self._bridge = bridge
         self._attr_device_info = device_info
         self._attr_unique_id = f"{bridge.serial_number}_{self.entity_description.key}"
+        self.entity_id = ENTITY_ID_FORMAT.format(f"{DOMAIN.lower()}_{self._attr_unique_id.lower()}")
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -1451,6 +1458,7 @@ class HuaweiSolarOptimizerSensorEntity(
 
         self._attr_device_info = device_info
         self._attr_unique_id = f"{device_info['name']}_{description.key}"
+        self.entity_id = ENTITY_ID_FORMAT.format(f"{DOMAIN.lower()}_{self._attr_unique_id.lower()}")
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/switch.py
+++ b/switch.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 import logging
 from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
-from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
+from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription, ENTITY_ID_FORMAT
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
@@ -154,6 +154,7 @@ class HuaweiSolarSwitchEntity(CoordinatorEntity, HuaweiSolarEntity, SwitchEntity
 
         self._attr_device_info = device_info
         self._attr_unique_id = f"{bridge.serial_number}_{description.key}"
+        self.entity_id = ENTITY_ID_FORMAT.format(f"{DOMAIN.lower()}_{self._attr_unique_id.lower()}")
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -240,6 +241,7 @@ class HuaweiSolarOnOffSwitchEntity(CoordinatorEntity, HuaweiSolarEntity, SwitchE
 
         self._attr_device_info = device_info
         self._attr_unique_id = f"{bridge.serial_number}_{self.entity_description.key}"
+        self.entity_id = ENTITY_ID_FORMAT.format(f"{DOMAIN.lower()}_{self._attr_unique_id.lower()}")
 
         self._change_lock = asyncio.Lock()
 


### PR DESCRIPTION
As mentioned here: #592 and #566  the entity_id should not be localized

The entity_id is now in the format: domain_serial_number_description.key
for  example: 
sensor.huawei_solar_hv***_input_power
switch.huawei_solar_hv***_startup

Tested with HA  Core 2024.6.3 