### PR TITLE
Adding polling interval in configuration, solves #718

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -134,9 +134,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # Now create update coordinators for each bridge
         update_coordinators: list[HuaweiSolarUpdateCoordinators] = []
 
-        inverter_update_interval = timedelta(entry.data.get(CONF_INVERTER_UPDATE_INTERVAL, INVERTER_UPDATE_INTERVAL.total_seconds()))
-        power_meter_update_interval = timedelta(entry.data.get(CONF_POWER_METER_UPDATE_INTERVAL, POWER_METER_UPDATE_INTERVAL.total_seconds()))
-        energy_storage_update_interval = timedelta(entry.data.get(CONF_ENERGY_STORAGE_UPDATE_INTERVAL, ENERGY_STORAGE_UPDATE_INTERVAL.total_seconds()))
+        inverter_update_interval = timedelta(seconds=entry.data.get(CONF_INVERTER_UPDATE_INTERVAL, INVERTER_UPDATE_INTERVAL.total_seconds()))
+        power_meter_update_interval = timedelta(seconds=entry.data.get(CONF_POWER_METER_UPDATE_INTERVAL, POWER_METER_UPDATE_INTERVAL.total_seconds()))
+        energy_storage_update_interval = timedelta(seconds=entry.data.get(CONF_ENERGY_STORAGE_UPDATE_INTERVAL, ENERGY_STORAGE_UPDATE_INTERVAL.total_seconds()))
 
         _LOGGER.info(f"Using update intervals: inverter={inverter_update_interval}, power_meter={power_meter_update_interval}, energy_storage={energy_storage_update_interval}")
 

--- a/__init__.py
+++ b/__init__.py
@@ -138,6 +138,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         power_meter_update_interval = timedelta(entry.data.get(CONF_POWER_METER_UPDATE_INTERVAL, POWER_METER_UPDATE_INTERVAL.total_seconds()))
         energy_storage_update_interval = timedelta(entry.data.get(CONF_ENERGY_STORAGE_UPDATE_INTERVAL, ENERGY_STORAGE_UPDATE_INTERVAL.total_seconds()))
 
+        _LOGGER.info(f"Using update intervals: inverter={inverter_update_interval}, power_meter={power_meter_update_interval}, energy_storage={energy_storage_update_interval}")
+
         for bridge, device_infos in bridges_with_device_infos:
             inverter_update_coordinator = HuaweiSolarUpdateCoordinator(
                 hass,

--- a/config_flow.py
+++ b/config_flow.py
@@ -27,7 +27,7 @@ from homeassistant.const import (
     CONF_USERNAME,
 )
 from homeassistant.data_entry_flow import FlowResult
-import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers import config_validation as cv, selector
 
 from .const import (
     CONF_ENABLE_PARAMETER_CONFIGURATION,
@@ -459,16 +459,35 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 ): str,
                 vol.Required(
                     CONF_INVERTER_UPDATE_INTERVAL,
-                    default=self._inverter_update_interval or INVERTER_UPDATE_INTERVAL.total_seconds(),
-                ): float,
+                    default=self._inverter_update_interval or float(INVERTER_UPDATE_INTERVAL.total_seconds()),
+                ): selector.NumberSelector(
+                        selector.NumberSelectorConfig(
+                            min=0.0,
+                            step=0.1,
+                            mode=selector.NumberSelectorMode.BOX,
+                        )
+                    ),
                 vol.Required(
                     CONF_POWER_METER_UPDATE_INTERVAL,
-                    default=self._power_meter_update_interval or POWER_METER_UPDATE_INTERVAL.total_seconds(),
-                ): float,
+                    default=self._power_meter_update_interval or float(POWER_METER_UPDATE_INTERVAL.total_seconds()),
+                ): selector.NumberSelector(
+                        selector.NumberSelectorConfig(
+                            min=0.0,
+                            step=0.1,
+                            mode=selector.NumberSelectorMode.BOX,
+                        )
+                    ),
                 vol.Required(
                     CONF_ENERGY_STORAGE_UPDATE_INTERVAL,
-                    default=self._energy_storage_update_interval or ENERGY_STORAGE_UPDATE_INTERVAL.total_seconds(),
-                ): float,
+                    default=self._energy_storage_update_interval or float(
+                        ENERGY_STORAGE_UPDATE_INTERVAL.total_seconds()),
+                ): selector.NumberSelector(
+                        selector.NumberSelectorConfig(
+                            min=0.0,
+                            step=0.1,
+                            mode=selector.NumberSelectorMode.BOX,
+                        )
+                    ),
             }
         )
         return self.async_show_form(
@@ -626,15 +645,33 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     vol.Required(
                         CONF_INVERTER_UPDATE_INTERVAL,
                         default=self._inverter_update_interval or INVERTER_UPDATE_INTERVAL.total_seconds(),
-                    ): float,
+                    ): selector.NumberSelector(
+                        selector.NumberSelectorConfig(
+                            min=0.0,
+                            step=0.1,
+                            mode=selector.NumberSelectorMode.BOX,
+                        )
+                    ),
                     vol.Required(
                         CONF_POWER_METER_UPDATE_INTERVAL,
                         default=self._power_meter_update_interval or POWER_METER_UPDATE_INTERVAL.total_seconds(),
-                    ): float,
+                    ): selector.NumberSelector(
+                        selector.NumberSelectorConfig(
+                            min=0.0,
+                            step=0.1,
+                            mode=selector.NumberSelectorMode.BOX,
+                        )
+                    ),
                     vol.Required(
                         CONF_ENERGY_STORAGE_UPDATE_INTERVAL,
                         default=self._energy_storage_update_interval or ENERGY_STORAGE_UPDATE_INTERVAL.total_seconds(),
-                    ): float,
+                    ): selector.NumberSelector(
+                        selector.NumberSelectorConfig(
+                            min=0.0,
+                            step=0.1,
+                            mode=selector.NumberSelectorMode.BOX,
+                        )
+                    ),
                 }
             ),
             errors=errors,

--- a/const.py
+++ b/const.py
@@ -14,9 +14,14 @@ CONF_ENABLE_PARAMETER_CONFIGURATION = "enable_parameter_configuration"
 
 DATA_UPDATE_COORDINATORS = "update_coordinators"
 
+CONF_INVERTER_UPDATE_INTERVAL = "inverter_update_interval"
+CONF_POWER_METER_UPDATE_INTERVAL = "power_meter_update_interval"
+CONF_ENERGY_STORAGE_UPDATE_INTERVAL = "energy_storage_update_interval"
+
 INVERTER_UPDATE_INTERVAL = timedelta(seconds=30)
 POWER_METER_UPDATE_INTERVAL = timedelta(seconds=30)
 ENERGY_STORAGE_UPDATE_INTERVAL = timedelta(seconds=30)
+
 UPDATE_TIMEOUT = timedelta(seconds=29)
 # configuration can only change when edited through FusionSolar web or app
 CONFIGURATION_UPDATE_INTERVAL = timedelta(minutes=15)

--- a/strings.json
+++ b/strings.json
@@ -27,9 +27,9 @@
                     "host": "Host",
                     "port": "Port",
                     "slave_ids": "Slave IDs: AUTO for auto-discovery, otherwise a comma separated list",
-                    "inverter_update_interval": "Inverter polling frequency in seconds, depends on your setup, use default if not sure",
-                    "power_meter_update_interval": "Power Meter polling frequency in seconds, depends on your setup, use default if not sure",
-                    "energy_storage_update_interval": "Energy Storage polling frequency in seconds, depends on your setup, use default if not sure"
+                    "inverter_update_interval": "Inverter polling frequency in seconds, depends on your setup",
+                    "power_meter_update_interval": "Power Meter polling frequency in seconds, depends on your setup",
+                    "energy_storage_update_interval": "Energy Storage polling frequency in seconds, depends on your setup"
                 }
             },
             "setup_serial": {

--- a/strings.json
+++ b/strings.json
@@ -26,13 +26,19 @@
                     "enable_parameter_configuration": "Advanced: elevate permissions",
                     "host": "Host",
                     "port": "Port",
-                    "slave_ids": "Slave IDs: AUTO for auto-discovery, otherwise a comma separated list"
+                    "slave_ids": "Slave IDs: AUTO for auto-discovery, otherwise a comma separated list",
+                    "inverter_update_interval": "Inverter polling frequency in seconds, depends on your setup, use default if not sure",
+                    "power_meter_update_interval": "Power Meter polling frequency in seconds, depends on your setup, use default if not sure",
+                    "energy_storage_update_interval": "Energy Storage polling frequency in seconds, depends on your setup, use default if not sure"
                 }
             },
             "setup_serial": {
                 "data": {
                     "port": "Select device",
-                    "slave_ids": "Slave IDs (Comma separated)"
+                    "slave_ids": "Slave IDs (Comma separated)",
+                    "inverter_update_interval": "[%key:component::huawei_solar::config::step::setup_network::data::inverter_update_interval%]",
+                    "power_meter_update_interval": "[%key:component::huawei_solar::config::step::setup_network::data::power_meter_update_interval%]",
+                    "energy_storage_update_interval": "[%key:component::huawei_solar::config::step::setup_network::data::energy_storage_update_interval%]"
                 },
                 "title": "Device"
             },

--- a/translations/en.json
+++ b/translations/en.json
@@ -27,18 +27,18 @@
                     "host": "Host",
                     "port": "Port",
                     "slave_ids": "Slave IDs: AUTO for auto-discovery, otherwise a comma separated list",
-                    "inverter_update_interval": "Inverter polling frequency in seconds, depends on your setup, use default if not sure",
-                    "power_meter_update_interval": "Power Meter polling frequency in seconds, depends on your setup, use default if not sure",
-                    "energy_storage_update_interval": "Energy Storage polling frequency in seconds, depends on your setup, use default if not sure"
+                    "inverter_update_interval": "Inverter polling frequency in seconds, depends on your setup",
+                    "power_meter_update_interval": "Power Meter polling frequency in seconds, depends on your setup",
+                    "energy_storage_update_interval": "Energy Storage polling frequency in seconds, depends on your setup"
                 }
             },
             "setup_serial": {
                 "data": {
                     "port": "Select device",
                     "slave_ids": "Slave IDs (Comma separated)",
-                    "inverter_update_interval": "Inverter polling frequency in seconds, depends on your setup, use default if not sure",
-                    "power_meter_update_interval": "Power Meter polling frequency in seconds, depends on your setup, use default if not sure",
-                    "energy_storage_update_interval": "Energy Storage polling frequency in seconds, depends on your setup, use default if not sure"
+                    "inverter_update_interval": "Inverter polling frequency in seconds, depends on your setup",
+                    "power_meter_update_interval": "Power Meter polling frequency in seconds, depends on your setup",
+                    "energy_storage_update_interval": "Energy Storage polling frequency in seconds, depends on your setup"
                 },
                 "title": "Device"
             },

--- a/translations/en.json
+++ b/translations/en.json
@@ -26,13 +26,19 @@
                     "enable_parameter_configuration": "Advanced: elevate permissions",
                     "host": "Host",
                     "port": "Port",
-                    "slave_ids": "Slave IDs: AUTO for auto-discovery, otherwise a comma separated list"
+                    "slave_ids": "Slave IDs: AUTO for auto-discovery, otherwise a comma separated list",
+                    "inverter_update_interval": "Inverter polling frequency in seconds, depends on your setup, use default if not sure",
+                    "power_meter_update_interval": "Power Meter polling frequency in seconds, depends on your setup, use default if not sure",
+                    "energy_storage_update_interval": "Energy Storage polling frequency in seconds, depends on your setup, use default if not sure"
                 }
             },
             "setup_serial": {
                 "data": {
                     "port": "Select device",
-                    "slave_ids": "Slave IDs (Comma separated)"
+                    "slave_ids": "Slave IDs (Comma separated)",
+                    "inverter_update_interval": "Inverter polling frequency in seconds, depends on your setup, use default if not sure",
+                    "power_meter_update_interval": "Power Meter polling frequency in seconds, depends on your setup, use default if not sure",
+                    "energy_storage_update_interval": "Energy Storage polling frequency in seconds, depends on your setup, use default if not sure"
                 },
                 "title": "Device"
             },


### PR DESCRIPTION
Hi, 

A small contribution to add the capability to set polling intervals for some sensors (inverter, energy storage, power meter). Working fine for my install in network mode.
Was related to the discussion: https://github.com/wlcrs/huawei_solar/discussions/718.
I put the setup in the configflow in serial and network mode, could be put before or another place, you tell me :)

BR
Thomas
