### PR TITLE
Allow target_soc below 12% in forcible charge/discharge services

### DIFF
--- a/services.py
+++ b/services.py
@@ -237,7 +237,7 @@ DURATION_SCHEMA = FORCIBLE_CHARGE_BASE_SCHEMA.extend(
 SOC_SCHEMA = FORCIBLE_CHARGE_BASE_SCHEMA.extend(
     {
         vol.Required(DATA_TARGET_SOC): vol.All(
-            vol.Coerce(float), vol.Range(min=12, max=100)
+            vol.Coerce(float), vol.Range(min=0, max=100)
         )
     }
 )

--- a/services.yaml
+++ b/services.yaml
@@ -57,7 +57,7 @@ forcible_charge_soc:
       default: 50
       selector:
         number:
-          min: 12
+          min: 0
           max: 100
           unit_of_measurement: "%"
     power:
@@ -79,7 +79,7 @@ forcible_discharge_soc:
       default: 15
       selector:
         number:
-          min: 12
+          min: 0
           max: 100
           unit_of_measurement: "%"
     power:


### PR DESCRIPTION
### Description
This PR lowers the hardcoded 12% minimum limit for `target_soc` to 0% in both `forcible_charge_soc` and `forcible_discharge_soc` services. 

### Motivation and Context
Currently, `services.py` and `services.yaml` strictly enforce a minimum `target_soc` of 12%. However, Huawei inverters and modern LUNA2000 batteries natively support lower End-of-Discharge limits.

When integrating external Energy Management Systems (EMS) like Predbat or EMHASS, the dynamically calculated discharge target often reflects the user's inverter settings (e.g., 10% or 11%). The current hardcoded 12% limit in this integration blocks these valid calls at the Home Assistant validation level, causing EMS automations to fail entirely.

By lowering the validation limit to `0`, we stop artificially restricting the integration and correctly delegate the hardware safety boundaries back to the inverter's internal BMS, "End-of-Discharge SOC", and "Backup SOC" configurations, which are designed to reject unsafe values automatically.