### PR TITLE
fix: stabilize SDongle setups with sensor profiles and resilient optimizer init

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ repository into the `custom_components/huawei_solar` directory
    - The port is either `502` or `6607`.
    - When connecting to the inverter AP the host IP is typically `192.168.200.1` and the slave id is typically `0`.
    - When connecting to an SDongle, the slave id is typically `1`. Make sure to give this device a fixed IP!
+   - `Sensor profile` controls which entity groups are created:
+     - `Minimum`: only stable core values (PV, meter and battery basics)
+     - `Normal`: recommended default for daily use
+     - `Custom`: choose groups manually (for example disable optimizer groups)
 
    Checking the `Advanced: elevate permissions` checkbox will:
    - give you access to optimizer data

--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ repository into the `custom_components/huawei_solar` directory
    - `Sensor profile` controls which entity groups are created:
      - `Minimum`: only stable core values (PV, meter and battery basics)
      - `Normal`: recommended default for daily use
-     - `Custom`: choose groups manually (for example disable optimizer groups)
+     - `All values`: full entity set (includes optimizer groups)
+     - `Custom`: choose groups manually, with quick presets for minimum/normal/all values
 
    Checking the `Advanced: elevate permissions` checkbox will:
    - give you access to optimizer data

--- a/__init__.py
+++ b/__init__.py
@@ -10,9 +10,7 @@ from huawei_solar import (
     SDongleDevice,
     SmartLoggerDevice,
     SUN2000Device,
-    create_device_instance,
     create_rtu_client,
-    create_sub_device_instance,
     create_tcp_client,
     register_values as rv,
 )
@@ -43,6 +41,15 @@ from .const import (
     OPTIMIZER_UPDATE_INTERVAL,
     POWER_METER_UPDATE_INTERVAL,
 )
+from .device_factory import (
+    create_device_instance_resilient,
+    create_sub_device_instance_resilient,
+)
+from .profiles import (
+    SENSOR_GROUP_OPTIMIZER_DETAIL,
+    get_selected_sensor_groups,
+    should_use_minimal_device_init,
+)
 from .services import async_setup_services
 from .types import (
     HuaweiSolarConfigEntry,
@@ -69,6 +76,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: HuaweiSolarConfigEntry) 
     """Set up Huawei Solar from a config entry."""
 
     primary_device = None
+    prefer_minimal_device_init = should_use_minimal_device_init(entry.data)
     try:
         # Multiple inverters can be connected to each other via a daisy chain,
         # via an internal modbus-network (ie. not the same modbus network that we are
@@ -104,7 +112,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: HuaweiSolarConfigEntry) 
                 unit_id=entry.data[CONF_SLAVE_IDS][0],
             )
 
-        primary_device = await create_device_instance(client)
+        primary_device = await create_device_instance_resilient(
+            client,
+            prefer_minimal=prefer_minimal_device_init,
+        )
 
         if entry.data.get(CONF_ENABLE_PARAMETER_CONFIGURATION):
             if (
@@ -128,7 +139,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: HuaweiSolarConfigEntry) 
         device_datas: list[HuaweiSolarDeviceData] = [primary_device_data]
 
         for extra_unit_id in entry.data[CONF_SLAVE_IDS][1:]:
-            sub_device = await create_sub_device_instance(primary_device, extra_unit_id)
+            sub_device = await create_sub_device_instance_resilient(
+                primary_device,
+                extra_unit_id,
+                prefer_minimal=prefer_minimal_device_init,
+            )
             sub_device_data = await _setup_device_data(hass, entry, sub_device)
 
             device_datas.append(sub_device_data)
@@ -189,6 +204,7 @@ async def _setup_inverter_device_data(
     device: SUN2000Device,
     connecting_inverter_device_id: tuple[str, str] | None,
 ) -> HuaweiSolarInverterData:
+    selected_sensor_groups = get_selected_sensor_groups(entry.data)
     device_registry = dr.async_get(hass)
 
     inverter_device_info = DeviceInfo(
@@ -291,10 +307,14 @@ async def _setup_inverter_device_data(
     optimizers_device_infos = {}
     optimizer_update_coordinator = None
 
-    # Add optimizer devices if optimizers are detected
-    if device.has_optimizers and (
+    # Add optimizer devices only when detail optimizer entities are enabled.
+    if (
+        SENSOR_GROUP_OPTIMIZER_DETAIL in selected_sensor_groups
+        and device.has_optimizers
+        and (
         # Optimizers are not accessible when connected through a SmartLogger
         not isinstance(device.primary_device, SmartLoggerDevice)
+        )
     ):
         try:
             optimizer_system_infos = (

--- a/config_flow.py
+++ b/config_flow.py
@@ -48,16 +48,21 @@ from .device_factory import (
 )
 from .profiles import (
     ALL_SENSOR_GROUPS,
+    SENSOR_GROUP_PRESET_MANUAL,
+    SENSOR_GROUP_PRESET_OPTIONS,
     SENSOR_GROUP_OPTIONS,
     SENSOR_PROFILE_CUSTOM,
     SENSOR_PROFILE_NORMAL,
     SENSOR_PROFILE_OPTIONS,
+    get_groups_for_preset,
+    get_matching_preset_for_groups,
     should_use_minimal_device_init,
 )
 
 _LOGGER = logging.getLogger(__name__)
 
 CONF_MANUAL_PATH = "Enter Manually"
+CONF_SENSOR_GROUP_PRESET = "sensor_group_preset"
 
 
 async def validate_serial_setup(port: str, unit_ids: list[int]) -> dict[str, Any]:
@@ -571,7 +576,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             if self._sensor_profile != SENSOR_PROFILE_CUSTOM:
                 self._sensor_groups = None
 
-            if self._sensor_profile == SENSOR_PROFILE_CUSTOM and self._sensor_groups is None:
+            if self._sensor_profile == SENSOR_PROFILE_CUSTOM:
                 self._pending_network_input = dict(user_input)
                 return await self.async_step_setup_sensor_profile_custom()
 
@@ -618,13 +623,26 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors = {}
 
         if user_input is not None:
-            selected_groups = user_input.get(CONF_SENSOR_GROUPS)
-            if isinstance(selected_groups, (list, set, tuple)):
-                self._sensor_groups = [
-                    group for group in selected_groups if group in SENSOR_GROUP_OPTIONS
-                ]
+            selected_preset = user_input.get(
+                CONF_SENSOR_GROUP_PRESET,
+                SENSOR_GROUP_PRESET_MANUAL,
+            )
+            if (
+                isinstance(selected_preset, str)
+                and selected_preset in SENSOR_GROUP_PRESET_OPTIONS
+                and selected_preset != SENSOR_GROUP_PRESET_MANUAL
+            ):
+                self._sensor_groups = list(get_groups_for_preset(selected_preset))
             else:
-                self._sensor_groups = list(ALL_SENSOR_GROUPS)
+                selected_groups = user_input.get(CONF_SENSOR_GROUPS)
+                if isinstance(selected_groups, (list, set, tuple)):
+                    self._sensor_groups = [
+                        group
+                        for group in selected_groups
+                        if group in SENSOR_GROUP_OPTIONS
+                    ]
+                else:
+                    self._sensor_groups = list(ALL_SENSOR_GROUPS)
 
             pending_input = self._pending_network_input
             self._pending_network_input = None
@@ -635,15 +653,24 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 if errors:
                     return self._show_setup_network_form(errors)
 
+        selected_groups = (
+            self._sensor_groups
+            if self._sensor_groups is not None
+            else list(ALL_SENSOR_GROUPS)
+        )
+        selected_preset = get_matching_preset_for_groups(set(selected_groups))
+
         return self.async_show_form(
             step_id="setup_sensor_profile_custom",
             data_schema=vol.Schema(
                 {
                     vol.Required(
+                        CONF_SENSOR_GROUP_PRESET,
+                        default=selected_preset,
+                    ): vol.In(SENSOR_GROUP_PRESET_OPTIONS),
+                    vol.Required(
                         CONF_SENSOR_GROUPS,
-                        default=self._sensor_groups
-                        if self._sensor_groups is not None
-                        else list(ALL_SENSOR_GROUPS),
+                        default=selected_groups,
                     ): cv.multi_select(SENSOR_GROUP_OPTIONS),
                 }
             ),

--- a/config_flow.py
+++ b/config_flow.py
@@ -11,9 +11,7 @@ from huawei_solar import (
     HuaweiSolarException,
     InvalidCredentials,
     ReadException,
-    create_device_instance,
     create_rtu_client,
-    create_sub_device_instance,
     create_tcp_client,
     get_device_infos,
 )
@@ -36,11 +34,25 @@ import homeassistant.helpers.config_validation as cv
 
 from .const import (
     CONF_ENABLE_PARAMETER_CONFIGURATION,
+    CONF_SENSOR_GROUPS,
+    CONF_SENSOR_PROFILE,
     CONF_SLAVE_IDS,
     DEFAULT_PORT,
     DEFAULT_SERIAL_SLAVE_ID,
     DEFAULT_USERNAME,
     DOMAIN,
+)
+from .device_factory import (
+    create_device_instance_resilient,
+    create_sub_device_instance_resilient,
+)
+from .profiles import (
+    ALL_SENSOR_GROUPS,
+    SENSOR_GROUP_OPTIONS,
+    SENSOR_PROFILE_CUSTOM,
+    SENSOR_PROFILE_NORMAL,
+    SENSOR_PROFILE_OPTIONS,
+    should_use_minimal_device_init,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -56,7 +68,7 @@ async def validate_serial_setup(port: str, unit_ids: list[int]) -> dict[str, Any
     )
     try:
         await client.connect()
-        device = await create_device_instance(client)
+        device = await create_device_instance_resilient(client, prefer_minimal=True)
 
         _LOGGER.info(
             "Successfully connected to device %s %s with SN %s",
@@ -73,7 +85,11 @@ async def validate_serial_setup(port: str, unit_ids: list[int]) -> dict[str, Any
         # Also validate the other slave-ids
         for slave_id in unit_ids[1:]:
             try:
-                slave_bridge = await create_sub_device_instance(device, slave_id)
+                slave_bridge = await create_sub_device_instance_resilient(
+                    device,
+                    slave_id,
+                    prefer_minimal=True,
+                )
 
                 _LOGGER.info(
                     "Successfully connected to sub device %s with ID %s: %s with SN %s",
@@ -99,6 +115,7 @@ async def validate_network_setup_auto_slave_discovery(
     host: str,
     port: int,
     elevated_permissions: bool,
+    prefer_minimal_device_init: bool,
 ) -> dict[str, Any]:
     """Validate that we can connect to the device via the provided host and port. Try to autodiscover the slave ids."""
 
@@ -128,7 +145,10 @@ async def validate_network_setup_auto_slave_discovery(
             raise DeviceException("Primary device has no device_id")
 
         # we assume the first device is the primary device
-        device = await create_device_instance(client.for_unit_id(device_info.device_id))
+        device = await create_device_instance_resilient(
+            client.for_unit_id(device_info.device_id),
+            prefer_minimal=prefer_minimal_device_init,
+        )
 
         _LOGGER.info(
             "Successfully connected to device with ID %s: %s %s with SN %s",
@@ -166,8 +186,10 @@ async def validate_network_setup_auto_slave_discovery(
                 device_info.software_version,
             )
             try:
-                sub_device = await create_sub_device_instance(
-                    device, device_info.device_id
+                sub_device = await create_sub_device_instance_resilient(
+                    device,
+                    device_info.device_id,
+                    prefer_minimal=prefer_minimal_device_init,
                 )
 
                 _LOGGER.info(
@@ -204,6 +226,7 @@ async def validate_network_setup(
     port: int,
     unit_ids: list[int],
     elevated_permissions: bool,
+    prefer_minimal_device_init: bool,
 ) -> dict[str, Any]:
     """Validate the user input allows us to connect.
 
@@ -216,7 +239,10 @@ async def validate_network_setup(
     )
     try:
         await client.connect()
-        device = await create_device_instance(client)
+        device = await create_device_instance_resilient(
+            client,
+            prefer_minimal=prefer_minimal_device_init,
+        )
 
         _LOGGER.info(
             "Successfully connected to device %s %s with SN %s",
@@ -235,7 +261,11 @@ async def validate_network_setup(
         # Also validate the other slave-ids
         for unit_id in unit_ids[1:]:
             try:
-                sub_device = await create_sub_device_instance(device, unit_id)
+                sub_device = await create_sub_device_instance_resilient(
+                    device,
+                    unit_id,
+                    prefer_minimal=prefer_minimal_device_init,
+                )
 
                 _LOGGER.info(
                     "Successfully connected to sub device %s %s: %s with SN %s",
@@ -270,6 +300,7 @@ async def validate_network_setup_login(
     password: str,
 ) -> bool:
     """Verify the installer username/password and test if it can perform a write-operation."""
+    bridge = None
     client = create_tcp_client(
         host=host,
         port=port,
@@ -278,7 +309,7 @@ async def validate_network_setup_login(
     try:
         # these parameters have already been tested in validate_input, so this should work fine!
         await client.connect()
-        bridge = await create_device_instance(client)
+        bridge = await create_device_instance_resilient(client, prefer_minimal=True)
 
         assert isinstance(bridge, HuaweiSolarDeviceWithLogin)
 
@@ -317,6 +348,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     _password: str | None = None
 
     _elevated_permissions = False
+    _sensor_profile = SENSOR_PROFILE_NORMAL
+    _sensor_groups: list[str] | None = None
+    _pending_network_input: dict[str, Any] | None = None
 
     # Only used in reauth flows:
     _reauth_entry: config_entries.ConfigEntry | None = None
@@ -354,6 +388,12 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._elevated_permissions = entry_data.get(
             CONF_ENABLE_PARAMETER_CONFIGURATION, False
         )
+        self._sensor_profile = entry_data.get(CONF_SENSOR_PROFILE, SENSOR_PROFILE_NORMAL)
+        stored_groups = entry_data.get(CONF_SENSOR_GROUPS)
+        if isinstance(stored_groups, list):
+            self._sensor_groups = [group for group in stored_groups if group in SENSOR_GROUP_OPTIONS]
+        else:
+            self._sensor_groups = None
 
     async def async_step_reconfigure(
         self, user_input: dict[str, Any] | None = None
@@ -527,76 +567,22 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors = {}
 
         if user_input is not None:
-            self._host = user_input[CONF_HOST]
-            assert self._host is not None
-            self._port = user_input[CONF_PORT]
-            assert self._port is not None
-            self._elevated_permissions = user_input[CONF_ENABLE_PARAMETER_CONFIGURATION]
+            self._sensor_profile = user_input[CONF_SENSOR_PROFILE]
+            if self._sensor_profile != SENSOR_PROFILE_CUSTOM:
+                self._sensor_groups = None
 
-            info = None
-            if user_input[CONF_SLAVE_IDS].lower() == "auto":
-                try:
-                    info = await validate_network_setup_auto_slave_discovery(
-                        host=self._host,
-                        port=self._port,
-                        elevated_permissions=self._elevated_permissions,
-                    )
-                    self._slave_ids = info.pop("slave_ids")
+            if self._sensor_profile == SENSOR_PROFILE_CUSTOM and self._sensor_groups is None:
+                self._pending_network_input = dict(user_input)
+                return await self.async_step_setup_sensor_profile_custom()
 
-                except (ConnectionException, ModbusConnectionError):
-                    errors["base"] = "cannot_connect"
-                except DeviceException:
-                    errors["base"] = "slave_cannot_connect"
-                except ReadException:
-                    _LOGGER.exception("Read exception while connecting via TCP")
-                    errors["base"] = "read_error"
-                except Exception:  # allowed in config flow
-                    _LOGGER.exception("Unexpected exception while connecting via TCP")
-                    errors["base"] = "unknown"
-            else:
-                try:
-                    self._slave_ids = list(
-                        map(int, user_input[CONF_SLAVE_IDS].split(","))
-                    )
-                except ValueError:
-                    errors["base"] = "invalid_slave_ids"
-                else:
-                    try:
-                        info = await validate_network_setup(
-                            host=self._host,
-                            port=self._port,
-                            unit_ids=self._slave_ids,
-                            elevated_permissions=self._elevated_permissions,
-                        )
-
-                    except (ConnectionException, ModbusConnectionError):
-                        errors["base"] = "cannot_connect"
-                    except DeviceException:
-                        errors["base"] = "slave_cannot_connect"
-                    except ReadException:
-                        _LOGGER.exception("Read exception while connecting via TCP")
-                        errors["base"] = "read_error"
-                    except Exception:  # allowed in config flow
-                        _LOGGER.exception(
-                            "Unexpected exception while connecting via TCP"
-                        )
-                        errors["base"] = "unknown"
-
-            # info will be set when we successfully connected to the inverter
+            info, errors = await self._validate_network_input(user_input)
             if info:
-                # Check if we need to ask for the login details
-                if self._elevated_permissions and info["has_write_permission"] is False:
-                    self.context["title_placeholders"] = {"name": info["model_name"]}
-                    self._inverter_info = info
-                    return await self.async_step_network_login()
+                return await self._handle_validated_network_info(info)
 
-                # In case of a reconfigure, the user can have unchecked the elevated permissions checkbox
-                self._username = None
-                self._password = None
+        return self._show_setup_network_form(errors)
 
-                # Otherwise, we can directly create the device entry!
-                return await self._create_or_update_entry(info)
-
+    def _show_setup_network_form(self, errors: dict[str, str]) -> ConfigFlowResult:
+        """Show the network setup form."""
         return self.async_show_form(
             step_id="setup_network",
             data_schema=vol.Schema(
@@ -615,10 +601,142 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         CONF_ENABLE_PARAMETER_CONFIGURATION,
                         default=self._elevated_permissions,
                     ): bool,
+                    vol.Required(
+                        CONF_SENSOR_PROFILE,
+                        default=self._sensor_profile,
+                    ): vol.In(SENSOR_PROFILE_OPTIONS),
                 }
             ),
             errors=errors,
         )
+
+    async def async_step_setup_sensor_profile_custom(
+        self,
+        user_input: dict[str, Any] | None = None,
+    ) -> ConfigFlowResult:
+        """Configure custom sensor groups for custom profile mode."""
+        errors = {}
+
+        if user_input is not None:
+            selected_groups = user_input.get(CONF_SENSOR_GROUPS)
+            if isinstance(selected_groups, (list, set, tuple)):
+                self._sensor_groups = [
+                    group for group in selected_groups if group in SENSOR_GROUP_OPTIONS
+                ]
+            else:
+                self._sensor_groups = list(ALL_SENSOR_GROUPS)
+
+            pending_input = self._pending_network_input
+            self._pending_network_input = None
+            if pending_input:
+                info, errors = await self._validate_network_input(pending_input)
+                if info:
+                    return await self._handle_validated_network_info(info)
+                if errors:
+                    return self._show_setup_network_form(errors)
+
+        return self.async_show_form(
+            step_id="setup_sensor_profile_custom",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_SENSOR_GROUPS,
+                        default=self._sensor_groups
+                        if self._sensor_groups is not None
+                        else list(ALL_SENSOR_GROUPS),
+                    ): cv.multi_select(SENSOR_GROUP_OPTIONS),
+                }
+            ),
+            errors=errors,
+        )
+
+    async def _validate_network_input(
+        self,
+        user_input: dict[str, Any],
+    ) -> tuple[dict[str, Any] | None, dict[str, str]]:
+        """Validate network parameters and return inverter info + errors."""
+        errors: dict[str, str] = {}
+
+        self._host = user_input[CONF_HOST]
+        assert self._host is not None
+        self._port = user_input[CONF_PORT]
+        assert self._port is not None
+        self._elevated_permissions = user_input[CONF_ENABLE_PARAMETER_CONFIGURATION]
+
+        prefer_minimal_device_init = should_use_minimal_device_init(
+            {
+                CONF_SENSOR_PROFILE: self._sensor_profile,
+                CONF_SENSOR_GROUPS: self._sensor_groups,
+            },
+        )
+
+        info = None
+        if user_input[CONF_SLAVE_IDS].lower() == "auto":
+            try:
+                info = await validate_network_setup_auto_slave_discovery(
+                    host=self._host,
+                    port=self._port,
+                    elevated_permissions=self._elevated_permissions,
+                    prefer_minimal_device_init=prefer_minimal_device_init,
+                )
+                self._slave_ids = info.pop("slave_ids")
+
+            except (ConnectionException, ModbusConnectionError):
+                errors["base"] = "cannot_connect"
+            except DeviceException:
+                errors["base"] = "slave_cannot_connect"
+            except ReadException:
+                _LOGGER.exception("Read exception while connecting via TCP")
+                errors["base"] = "read_error"
+            except Exception:  # allowed in config flow
+                _LOGGER.exception("Unexpected exception while connecting via TCP")
+                errors["base"] = "unknown"
+        else:
+            try:
+                self._slave_ids = list(
+                    map(int, user_input[CONF_SLAVE_IDS].split(","))
+                )
+            except ValueError:
+                errors["base"] = "invalid_slave_ids"
+            else:
+                try:
+                    info = await validate_network_setup(
+                        host=self._host,
+                        port=self._port,
+                        unit_ids=self._slave_ids,
+                        elevated_permissions=self._elevated_permissions,
+                        prefer_minimal_device_init=prefer_minimal_device_init,
+                    )
+                except (ConnectionException, ModbusConnectionError):
+                    errors["base"] = "cannot_connect"
+                except DeviceException:
+                    errors["base"] = "slave_cannot_connect"
+                except ReadException:
+                    _LOGGER.exception("Read exception while connecting via TCP")
+                    errors["base"] = "read_error"
+                except Exception:  # allowed in config flow
+                    _LOGGER.exception(
+                        "Unexpected exception while connecting via TCP"
+                    )
+                    errors["base"] = "unknown"
+
+        return info, errors
+
+    async def _handle_validated_network_info(
+        self,
+        info: dict[str, Any],
+    ) -> ConfigFlowResult:
+        """Handle a successful network validation result."""
+        if self._elevated_permissions and info["has_write_permission"] is False:
+            self.context["title_placeholders"] = {"name": info["model_name"]}
+            self._inverter_info = info
+            return await self.async_step_network_login()
+
+        # In case of a reconfigure, the user can have unchecked elevated permissions.
+        self._username = None
+        self._password = None
+
+        return await self._create_or_update_entry(info)
 
     async def async_step_network_login(
         self, user_input: dict[str, Any] | None = None
@@ -692,6 +810,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             CONF_ENABLE_PARAMETER_CONFIGURATION: self._elevated_permissions,
             CONF_USERNAME: self._username,
             CONF_PASSWORD: self._password,
+            CONF_SENSOR_PROFILE: self._sensor_profile,
+            CONF_SENSOR_GROUPS: self._sensor_groups
+            if self._sensor_profile == SENSOR_PROFILE_CUSTOM
+            else None,
         }
 
         if self._reauth_entry:

--- a/const.py
+++ b/const.py
@@ -11,6 +11,8 @@ DEFAULT_PASSWORD = "00000a"
 
 CONF_SLAVE_IDS = "slave_ids"
 CONF_ENABLE_PARAMETER_CONFIGURATION = "enable_parameter_configuration"
+CONF_SENSOR_PROFILE = "sensor_profile"
+CONF_SENSOR_GROUPS = "sensor_groups"
 
 DATA_DEVICE_DATAS = "device_datas"
 DATA_UPDATE_COORDINATORS = "update_coordinators"

--- a/device_factory.py
+++ b/device_factory.py
@@ -1,0 +1,167 @@
+"""Device creation helpers with resilient SUN2000 fallback initialization."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from huawei_solar import (
+    HuaweiSolarException,
+    ReadException,
+    register_names as rn,
+    register_values as rv,
+)
+from huawei_solar.device import (
+    create_device_instance,
+    create_sub_device_instance,
+)
+from huawei_solar.device.base import HuaweiSolarDevice
+from huawei_solar.device.sun2000 import SUN2000Device
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _is_sun2000_model(model_name: str) -> bool:
+    return model_name.startswith(("SUN", "EDF ESS", "Powershifter", "SWI300"))
+
+
+def _compute_pv_registers(pv_string_count: int) -> list[str]:
+    if not 1 <= pv_string_count <= 24:
+        return []
+    return [
+        register_name
+        for idx in range(1, pv_string_count + 1)
+        for register_name in (
+            getattr(rn, f"PV_{idx:02}_VOLTAGE"),
+            getattr(rn, f"PV_{idx:02}_CURRENT"),
+        )
+    ]
+
+
+async def _safe_get(device: HuaweiSolarDevice, register: rn.RegisterName, default: Any) -> Any:
+    try:
+        return (await device.get(register)).value
+    except (HuaweiSolarException, TimeoutError, ReadException):
+        return default
+
+
+async def _populate_sun2000_minimal(device: SUN2000Device) -> None:
+    """Populate the minimum required SUN2000 fields without optimizer probing."""
+    serial_number = await _safe_get(device, rn.SERIAL_NUMBER, None)
+    product_number = await _safe_get(device, rn.PN, "")
+    firmware_version = await _safe_get(device, rn.FIRMWARE_VERSION, "")
+    software_version = await _safe_get(device, rn.SOFTWARE_VERSION, "")
+
+    if serial_number in (None, ""):
+        serial_number = f"{device.model_name}_{device.client.unit_id}"
+
+    device.serial_number = str(serial_number)
+    device.product_number = str(product_number)
+    device.firmware_version = str(firmware_version)
+    device.software_version = str(software_version)
+
+    pv_string_count = await _safe_get(device, rn.NB_PV_STRINGS, 1)
+    if not isinstance(pv_string_count, int):
+        pv_string_count = 1
+    if pv_string_count < 1:
+        pv_string_count = 1
+    device.pv_string_count = pv_string_count
+    device._pv_registers = _compute_pv_registers(pv_string_count)
+
+    # Explicitly skip optimizer probing in fallback mode.
+    device.has_optimizers = False
+
+    device.battery_1_type = await _safe_get(
+        device,
+        rn.STORAGE_UNIT_1_PRODUCT_MODEL,
+        rv.StorageProductModel.NONE,
+    )
+    device.battery_2_type = await _safe_get(
+        device,
+        rn.STORAGE_UNIT_2_PRODUCT_MODEL,
+        rv.StorageProductModel.NONE,
+    )
+    device.supports_capacity_control = False
+
+    meter_status = await _safe_get(device, rn.METER_STATUS, None)
+    device.power_meter_online = meter_status == rv.MeterStatus.NORMAL
+    if device.power_meter_online:
+        device.power_meter_type = await _safe_get(device, rn.METER_TYPE, None)
+    else:
+        device.power_meter_type = None
+
+    device._dst = await _safe_get(device, rn.DAYLIGHT_SAVING_TIME, None)
+    device._time_zone = await _safe_get(device, rn.TIME_ZONE, None)
+
+
+async def _create_sun2000_minimal(
+    client: Any,
+    model_name: str,
+    primary_device: HuaweiSolarDevice | None,
+) -> SUN2000Device:
+    device = SUN2000Device(
+        client,
+        model_name=model_name,
+        primary_device=primary_device,
+    )
+    await _populate_sun2000_minimal(device)
+    return device
+
+
+async def create_device_instance_resilient(
+    client: Any,
+    *,
+    prefer_minimal: bool,
+) -> HuaweiSolarDevice:
+    """Create device instance with minimal SUN2000 fallback when needed."""
+    model_name = (await client.get(rn.MODEL_NAME)).value
+    if isinstance(model_name, str) and _is_sun2000_model(model_name):
+        if prefer_minimal:
+            _LOGGER.info(
+                "Using minimal SUN2000 initialization path for unit %s",
+                client.unit_id,
+            )
+            return await _create_sun2000_minimal(client, model_name, None)
+
+        try:
+            return await create_device_instance(client)
+        except (TimeoutError, HuaweiSolarException) as err:
+            _LOGGER.warning(
+                "Falling back to minimal SUN2000 initialization for unit %s: %s",
+                client.unit_id,
+                err,
+            )
+            return await _create_sun2000_minimal(client, model_name, None)
+
+    return await create_device_instance(client)
+
+
+async def create_sub_device_instance_resilient(
+    primary_device: HuaweiSolarDevice,
+    unit_id: int,
+    *,
+    prefer_minimal: bool,
+) -> HuaweiSolarDevice:
+    """Create sub-device instance with minimal SUN2000 fallback when needed."""
+    sub_client = primary_device.client.for_unit_id(unit_id)
+    model_name = (await sub_client.get(rn.MODEL_NAME)).value
+
+    if isinstance(model_name, str) and _is_sun2000_model(model_name):
+        if prefer_minimal:
+            _LOGGER.info(
+                "Using minimal SUN2000 initialization path for sub-device unit %s",
+                unit_id,
+            )
+            return await _create_sun2000_minimal(sub_client, model_name, primary_device)
+
+        try:
+            return await create_sub_device_instance(primary_device, unit_id)
+        except (TimeoutError, HuaweiSolarException) as err:
+            _LOGGER.warning(
+                "Falling back to minimal SUN2000 sub-device initialization for unit %s: %s",
+                unit_id,
+                err,
+            )
+            return await _create_sun2000_minimal(sub_client, model_name, primary_device)
+
+    return await create_sub_device_instance(primary_device, unit_id)

--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,7 @@
         "@wlcrs"
     ],
     "iot_class": "local_polling",
-    "version": "2.0.0b5.post1",
+    "version": "2.0.0b5.post2",
     "loggers": [
         "huawei_solar",
         "tmodbus"

--- a/manifest.json
+++ b/manifest.json
@@ -1,12 +1,12 @@
 {
     "domain": "huawei_solar",
-    "name": "Huawei Solar",
+    "name": "Huawei Solar_SW",
     "after_dependencies": [
         "usb"
     ],
     "config_flow": true,
-    "documentation": "https://github.com/wlcrs/huawei_solar/wiki",
-    "issue_tracker": "https://github.com/wlcrs/huawei_solar/issues",
+    "documentation": "https://github.com/StefanWokusch/huawei_solar/wiki",
+    "issue_tracker": "https://github.com/StefanWokusch/huawei_solar/issues",
     "requirements": [
         "huawei-solar>=3.0.0b2"
     ],
@@ -14,7 +14,7 @@
         "@wlcrs"
     ],
     "iot_class": "local_polling",
-    "version": "2.0.0b5",
+    "version": "2.0.0b5.post1",
     "loggers": [
         "huawei_solar",
         "tmodbus"

--- a/profiles.py
+++ b/profiles.py
@@ -1,0 +1,92 @@
+"""Sensor profile configuration for Huawei Solar."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from .const import CONF_SENSOR_GROUPS, CONF_SENSOR_PROFILE
+
+SENSOR_PROFILE_MINIMUM = "minimum"
+SENSOR_PROFILE_NORMAL = "normal"
+SENSOR_PROFILE_CUSTOM = "custom"
+
+SENSOR_PROFILE_OPTIONS = {
+    SENSOR_PROFILE_MINIMUM: "Minimum (stable core values)",
+    SENSOR_PROFILE_NORMAL: "Normal (recommended)",
+    SENSOR_PROFILE_CUSTOM: "Custom (choose groups)",
+}
+
+SENSOR_GROUP_INVERTER_CORE = "inverter_core"
+SENSOR_GROUP_INVERTER_DIAGNOSTICS = "inverter_diagnostics"
+SENSOR_GROUP_PV_STRINGS = "pv_strings"
+SENSOR_GROUP_METER_BASIC = "meter_basic"
+SENSOR_GROUP_METER_ADVANCED = "meter_advanced"
+SENSOR_GROUP_BATTERY_BASIC = "battery_basic"
+SENSOR_GROUP_BATTERY_DETAIL = "battery_detail"
+SENSOR_GROUP_OPTIMIZER_SUMMARY = "optimizer_summary"
+SENSOR_GROUP_OPTIMIZER_DETAIL = "optimizer_detail"
+
+SENSOR_GROUP_OPTIONS = {
+    SENSOR_GROUP_INVERTER_CORE: "Inverter core values",
+    SENSOR_GROUP_INVERTER_DIAGNOSTICS: "Inverter diagnostics",
+    SENSOR_GROUP_PV_STRINGS: "PV string values",
+    SENSOR_GROUP_METER_BASIC: "Power meter basic values",
+    SENSOR_GROUP_METER_ADVANCED: "Power meter advanced values",
+    SENSOR_GROUP_BATTERY_BASIC: "Battery basic values",
+    SENSOR_GROUP_BATTERY_DETAIL: "Battery detail values",
+    SENSOR_GROUP_OPTIMIZER_SUMMARY: "Optimizer summary values",
+    SENSOR_GROUP_OPTIMIZER_DETAIL: "Optimizer detail values",
+}
+
+DEFAULT_MINIMUM_SENSOR_GROUPS: tuple[str, ...] = (
+    SENSOR_GROUP_INVERTER_CORE,
+    SENSOR_GROUP_METER_BASIC,
+    SENSOR_GROUP_BATTERY_BASIC,
+)
+
+DEFAULT_NORMAL_SENSOR_GROUPS: tuple[str, ...] = (
+    SENSOR_GROUP_INVERTER_CORE,
+    SENSOR_GROUP_INVERTER_DIAGNOSTICS,
+    SENSOR_GROUP_PV_STRINGS,
+    SENSOR_GROUP_METER_BASIC,
+    SENSOR_GROUP_METER_ADVANCED,
+    SENSOR_GROUP_BATTERY_BASIC,
+    SENSOR_GROUP_BATTERY_DETAIL,
+)
+
+ALL_SENSOR_GROUPS: tuple[str, ...] = tuple(SENSOR_GROUP_OPTIONS.keys())
+
+
+def sanitize_sensor_groups(
+    groups: list[str] | tuple[str, ...] | set[str] | None,
+) -> set[str]:
+    """Return known groups only."""
+    if groups is None:
+        return set()
+    return {group for group in groups if group in SENSOR_GROUP_OPTIONS}
+
+
+def get_selected_sensor_groups(config: Mapping[str, Any]) -> set[str]:
+    """Resolve selected sensor groups from profile + optional custom selection."""
+    profile = config.get(CONF_SENSOR_PROFILE, SENSOR_PROFILE_NORMAL)
+
+    if profile == SENSOR_PROFILE_MINIMUM:
+        return set(DEFAULT_MINIMUM_SENSOR_GROUPS)
+
+    if profile == SENSOR_PROFILE_CUSTOM:
+        custom_groups = config.get(CONF_SENSOR_GROUPS)
+        if isinstance(custom_groups, (list, tuple, set)):
+            return sanitize_sensor_groups(custom_groups)
+        return set(ALL_SENSOR_GROUPS)
+
+    return set(DEFAULT_NORMAL_SENSOR_GROUPS)
+
+
+def should_use_minimal_device_init(config: Mapping[str, Any]) -> bool:
+    """Use full SUN2000 discovery only when optimizer detail entities are requested."""
+    profile = config.get(CONF_SENSOR_PROFILE, SENSOR_PROFILE_NORMAL)
+    if profile != SENSOR_PROFILE_CUSTOM:
+        return True
+
+    custom_groups = get_selected_sensor_groups(config)
+    return SENSOR_GROUP_OPTIMIZER_DETAIL not in custom_groups

--- a/profiles.py
+++ b/profiles.py
@@ -8,11 +8,13 @@ from .const import CONF_SENSOR_GROUPS, CONF_SENSOR_PROFILE
 
 SENSOR_PROFILE_MINIMUM = "minimum"
 SENSOR_PROFILE_NORMAL = "normal"
+SENSOR_PROFILE_ALL_VALUES = "all_values"
 SENSOR_PROFILE_CUSTOM = "custom"
 
 SENSOR_PROFILE_OPTIONS = {
     SENSOR_PROFILE_MINIMUM: "Minimum (stable core values)",
     SENSOR_PROFILE_NORMAL: "Normal (recommended)",
+    SENSOR_PROFILE_ALL_VALUES: "All values (full)",
     SENSOR_PROFILE_CUSTOM: "Custom (choose groups)",
 }
 
@@ -56,6 +58,18 @@ DEFAULT_NORMAL_SENSOR_GROUPS: tuple[str, ...] = (
 
 ALL_SENSOR_GROUPS: tuple[str, ...] = tuple(SENSOR_GROUP_OPTIONS.keys())
 
+SENSOR_GROUP_PRESET_MINIMUM = "minimum"
+SENSOR_GROUP_PRESET_NORMAL = "normal"
+SENSOR_GROUP_PRESET_ALL_VALUES = "all_values"
+SENSOR_GROUP_PRESET_MANUAL = "manual"
+
+SENSOR_GROUP_PRESET_OPTIONS = {
+    SENSOR_GROUP_PRESET_MINIMUM: "Minimum",
+    SENSOR_GROUP_PRESET_NORMAL: "Normal",
+    SENSOR_GROUP_PRESET_ALL_VALUES: "All values",
+    SENSOR_GROUP_PRESET_MANUAL: "Manual selection",
+}
+
 
 def sanitize_sensor_groups(
     groups: list[str] | tuple[str, ...] | set[str] | None,
@@ -79,14 +93,41 @@ def get_selected_sensor_groups(config: Mapping[str, Any]) -> set[str]:
             return sanitize_sensor_groups(custom_groups)
         return set(ALL_SENSOR_GROUPS)
 
+    if profile == SENSOR_PROFILE_ALL_VALUES:
+        return set(ALL_SENSOR_GROUPS)
+
     return set(DEFAULT_NORMAL_SENSOR_GROUPS)
 
 
 def should_use_minimal_device_init(config: Mapping[str, Any]) -> bool:
     """Use full SUN2000 discovery only when optimizer detail entities are requested."""
     profile = config.get(CONF_SENSOR_PROFILE, SENSOR_PROFILE_NORMAL)
-    if profile != SENSOR_PROFILE_CUSTOM:
+    if profile in (SENSOR_PROFILE_MINIMUM, SENSOR_PROFILE_NORMAL):
         return True
+    if profile == SENSOR_PROFILE_ALL_VALUES:
+        return False
 
     custom_groups = get_selected_sensor_groups(config)
     return SENSOR_GROUP_OPTIMIZER_DETAIL not in custom_groups
+
+
+def get_groups_for_preset(preset: str) -> set[str]:
+    """Return sensor groups for a custom preset option."""
+    if preset == SENSOR_GROUP_PRESET_MINIMUM:
+        return set(DEFAULT_MINIMUM_SENSOR_GROUPS)
+    if preset == SENSOR_GROUP_PRESET_NORMAL:
+        return set(DEFAULT_NORMAL_SENSOR_GROUPS)
+    if preset == SENSOR_GROUP_PRESET_ALL_VALUES:
+        return set(ALL_SENSOR_GROUPS)
+    return set()
+
+
+def get_matching_preset_for_groups(groups: set[str]) -> str:
+    """Resolve preset name for known group combinations."""
+    if groups == set(DEFAULT_MINIMUM_SENSOR_GROUPS):
+        return SENSOR_GROUP_PRESET_MINIMUM
+    if groups == set(DEFAULT_NORMAL_SENSOR_GROUPS):
+        return SENSOR_GROUP_PRESET_NORMAL
+    if groups == set(ALL_SENSOR_GROUPS):
+        return SENSOR_GROUP_PRESET_ALL_VALUES
+    return SENSOR_GROUP_PRESET_MANUAL

--- a/sensor.py
+++ b/sensor.py
@@ -46,6 +46,18 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DATA_DEVICE_DATAS
+from .profiles import (
+    SENSOR_GROUP_BATTERY_BASIC,
+    SENSOR_GROUP_BATTERY_DETAIL,
+    SENSOR_GROUP_INVERTER_CORE,
+    SENSOR_GROUP_INVERTER_DIAGNOSTICS,
+    SENSOR_GROUP_METER_ADVANCED,
+    SENSOR_GROUP_METER_BASIC,
+    SENSOR_GROUP_OPTIMIZER_DETAIL,
+    SENSOR_GROUP_OPTIMIZER_SUMMARY,
+    SENSOR_GROUP_PV_STRINGS,
+    get_selected_sensor_groups,
+)
 from .types import (
     HuaweiSolarConfigEntry,
     HuaweiSolarDeviceData,
@@ -1103,21 +1115,81 @@ BATTERY_TEMPLATE_SENSOR_DESCRIPTIONS: tuple[BatteryTemplateEntityDescription, ..
 )
 
 
-async def create_sun2000_entities(ucs: HuaweiSolarInverterData) -> list[SensorEntity]:
+INVERTER_CORE_REGISTER_NAMES = {
+    rn.INPUT_POWER,
+    rn.ACTIVE_POWER,
+    rn.ACTIVE_POWER_FAST,
+    rn.ACCUMULATED_YIELD_ENERGY,
+    rn.DAILY_YIELD_ENERGY,
+    rn.MONTHLY_YIELD_ENERGY,
+    rn.YEARLY_YIELD_ENERGY,
+}
+
+METER_BASIC_REGISTER_NAMES = {
+    rn.POWER_METER_ACTIVE_POWER,
+    rn.GRID_EXPORTED_ENERGY,
+    rn.GRID_ACCUMULATED_ENERGY,
+}
+
+BATTERY_BASIC_REGISTER_NAMES = {
+    rn.STORAGE_STATE_OF_CAPACITY,
+    rn.STORAGE_CHARGE_DISCHARGE_POWER,
+    rn.STORAGE_RUNNING_STATUS,
+}
+
+
+def _base_key(key: str) -> str:
+    return key.split("#")[0]
+
+
+def _filter_descriptions_by_base_register(
+    descriptions: tuple[HuaweiSolarSensorEntityDescription, ...],
+    allowed_register_names: set[str],
+) -> list[HuaweiSolarSensorEntityDescription]:
+    return [
+        description
+        for description in descriptions
+        if _base_key(description.key) in allowed_register_names
+    ]
+
+
+def _filter_descriptions_excluding_base_register(
+    descriptions: tuple[HuaweiSolarSensorEntityDescription, ...],
+    excluded_register_names: set[str],
+) -> list[HuaweiSolarSensorEntityDescription]:
+    return [
+        description
+        for description in descriptions
+        if _base_key(description.key) not in excluded_register_names
+    ]
+
+
+async def create_sun2000_entities(
+    ucs: HuaweiSolarInverterData,
+    selected_sensor_groups: set[str],
+) -> list[SensorEntity]:
     """Create SUN2000 sensor entities."""
     entities_to_add: list[SensorEntity] = []
 
-    entities_to_add.extend(
-        HuaweiSolarSensorEntity(
-            ucs.update_coordinator,
-            entity_description,
-            ucs.device_info,
+    inverter_descriptions: list[HuaweiSolarSensorEntityDescription] = []
+    if SENSOR_GROUP_INVERTER_CORE in selected_sensor_groups:
+        inverter_descriptions.extend(
+            _filter_descriptions_by_base_register(
+                INVERTER_SENSOR_DESCRIPTIONS,
+                INVERTER_CORE_REGISTER_NAMES,
+            )
         )
-        for entity_description in INVERTER_SENSOR_DESCRIPTIONS
-    )
-    entities_to_add.append(
-        HuaweiSolarAlarmSensorEntity(ucs.update_coordinator, ucs.device_info)
-    )
+
+    if SENSOR_GROUP_INVERTER_DIAGNOSTICS in selected_sensor_groups:
+        inverter_descriptions.extend(
+            _filter_descriptions_excluding_base_register(
+                INVERTER_SENSOR_DESCRIPTIONS,
+                INVERTER_CORE_REGISTER_NAMES,
+            )
+        )
+        entities_to_add.append(
+            HuaweiSolarAlarmSensorEntity(ucs.update_coordinator, ucs.device_info)
+        )
 
     entities_to_add.extend(
         HuaweiSolarSensorEntity(
@@ -1125,10 +1197,20 @@ async def create_sun2000_entities(ucs: HuaweiSolarInverterData) -> list[SensorEn
             entity_description,
             ucs.device_info,
         )
-        for entity_description in get_pv_entity_descriptions(ucs.device.pv_string_count)
+        for entity_description in inverter_descriptions
     )
 
-    if ucs.device.has_optimizers:
+    if SENSOR_GROUP_PV_STRINGS in selected_sensor_groups:
+        entities_to_add.extend(
+            HuaweiSolarSensorEntity(
+                ucs.update_coordinator,
+                entity_description,
+                ucs.device_info,
+            )
+            for entity_description in get_pv_entity_descriptions(ucs.device.pv_string_count)
+        )
+
+    if SENSOR_GROUP_OPTIMIZER_SUMMARY in selected_sensor_groups:
         entities_to_add.extend(
             HuaweiSolarSensorEntity(
                 ucs.update_coordinator,
@@ -1141,27 +1223,58 @@ async def create_sun2000_entities(ucs: HuaweiSolarInverterData) -> list[SensorEn
     if ucs.device.power_meter_type == rv.MeterType.SINGLE_PHASE:
         assert ucs.power_meter_update_coordinator
         assert ucs.power_meter
+        meter_descriptions = []
+        if SENSOR_GROUP_METER_BASIC in selected_sensor_groups:
+            meter_descriptions.extend(
+                _filter_descriptions_by_base_register(
+                    SINGLE_PHASE_METER_ENTITY_DESCRIPTIONS,
+                    METER_BASIC_REGISTER_NAMES,
+                )
+            )
+        if SENSOR_GROUP_METER_ADVANCED in selected_sensor_groups:
+            meter_descriptions.extend(
+                _filter_descriptions_excluding_base_register(
+                    SINGLE_PHASE_METER_ENTITY_DESCRIPTIONS,
+                    METER_BASIC_REGISTER_NAMES,
+                )
+            )
         entities_to_add.extend(
             HuaweiSolarSensorEntity(
                 ucs.power_meter_update_coordinator, entity_description, ucs.power_meter
             )
-            for entity_description in SINGLE_PHASE_METER_ENTITY_DESCRIPTIONS
+            for entity_description in meter_descriptions
         )
 
     elif ucs.device.power_meter_type == rv.MeterType.THREE_PHASE:
         assert ucs.power_meter_update_coordinator
         assert ucs.power_meter
+        meter_descriptions = []
+        if SENSOR_GROUP_METER_BASIC in selected_sensor_groups:
+            meter_descriptions.extend(
+                _filter_descriptions_by_base_register(
+                    THREE_PHASE_METER_ENTITY_DESCRIPTIONS,
+                    METER_BASIC_REGISTER_NAMES,
+                )
+            )
+        if SENSOR_GROUP_METER_ADVANCED in selected_sensor_groups:
+            meter_descriptions.extend(
+                _filter_descriptions_excluding_base_register(
+                    THREE_PHASE_METER_ENTITY_DESCRIPTIONS,
+                    METER_BASIC_REGISTER_NAMES,
+                )
+            )
         entities_to_add.extend(
             HuaweiSolarSensorEntity(
                 ucs.power_meter_update_coordinator, entity_description, ucs.power_meter
             )
-            for entity_description in THREE_PHASE_METER_ENTITY_DESCRIPTIONS
+            for entity_description in meter_descriptions
         )
 
     if (
         not isinstance(ucs.device.primary_device, EMMADevice)
         and await ucs.device.has_write_permission()
         and ucs.configuration_update_coordinator
+        and SENSOR_GROUP_INVERTER_DIAGNOSTICS in selected_sensor_groups
     ):
         entities_to_add.append(
             HuaweiSolarActivePowerControlModeEntity(
@@ -1175,16 +1288,35 @@ async def create_sun2000_entities(ucs: HuaweiSolarInverterData) -> list[SensorEn
         assert ucs.energy_storage_update_coordinator
         assert ucs.connected_energy_storage
 
+        battery_descriptions: list[HuaweiSolarSensorEntityDescription] = []
+        if SENSOR_GROUP_BATTERY_BASIC in selected_sensor_groups:
+            battery_descriptions.extend(
+                _filter_descriptions_by_base_register(
+                    BATTERIES_SENSOR_DESCRIPTIONS,
+                    BATTERY_BASIC_REGISTER_NAMES,
+                )
+            )
+        if SENSOR_GROUP_BATTERY_DETAIL in selected_sensor_groups:
+            battery_descriptions.extend(
+                _filter_descriptions_excluding_base_register(
+                    BATTERIES_SENSOR_DESCRIPTIONS,
+                    BATTERY_BASIC_REGISTER_NAMES,
+                )
+            )
+
         entities_to_add.extend(
             HuaweiSolarSensorEntity(
                 ucs.energy_storage_update_coordinator,
                 entity_description,
                 ucs.connected_energy_storage,
             )
-            for entity_description in BATTERIES_SENSOR_DESCRIPTIONS
+            for entity_description in battery_descriptions
         )
 
-        if ucs.configuration_update_coordinator:
+        if (
+            ucs.configuration_update_coordinator
+            and SENSOR_GROUP_BATTERY_DETAIL in selected_sensor_groups
+        ):
             if ucs.device.battery_type == rv.StorageProductModel.HUAWEI_LUNA2000:
                 entities_to_add.append(
                     HuaweiSolarTOUSensorEntity(
@@ -1218,7 +1350,7 @@ async def create_sun2000_entities(ucs: HuaweiSolarInverterData) -> list[SensorEn
                     )
                 )
 
-        if ucs.battery_1:
+        if ucs.battery_1 and SENSOR_GROUP_BATTERY_DETAIL in selected_sensor_groups:
             entities_to_add.extend(
                 HuaweiSolarSensorEntity(
                     ucs.energy_storage_update_coordinator,
@@ -1238,7 +1370,7 @@ async def create_sun2000_entities(ucs: HuaweiSolarInverterData) -> list[SensorEn
                 if entity_description_template.battery_1_key
             )
 
-        if ucs.battery_2:
+        if ucs.battery_2 and SENSOR_GROUP_BATTERY_DETAIL in selected_sensor_groups:
             entities_to_add.extend(
                 HuaweiSolarSensorEntity(
                     ucs.energy_storage_update_coordinator,
@@ -1257,7 +1389,10 @@ async def create_sun2000_entities(ucs: HuaweiSolarInverterData) -> list[SensorEn
                 for entity_description_template in BATTERY_TEMPLATE_SENSOR_DESCRIPTIONS
                 if entity_description_template.battery_2_key
             )
-    if ucs.optimizer_update_coordinator:
+    if (
+        SENSOR_GROUP_OPTIMIZER_DETAIL in selected_sensor_groups
+        and ucs.optimizer_update_coordinator
+    ):
         optimizer_device_infos = ucs.optimizer_update_coordinator.optimizer_device_infos
 
         entities_to_add.extend(
@@ -2038,11 +2173,14 @@ async def async_setup_entry(
 ) -> None:
     """Add Huawei Solar entry."""
     device_datas: list[HuaweiSolarDeviceData] = entry.runtime_data[DATA_DEVICE_DATAS]
+    selected_sensor_groups = get_selected_sensor_groups(entry.data)
 
     entities_to_add = []
     for ucs in device_datas:
         if isinstance(ucs, HuaweiSolarInverterData):
-            entities_to_add.extend(await create_sun2000_entities(ucs))
+            entities_to_add.extend(
+                await create_sun2000_entities(ucs, selected_sensor_groups)
+            )
         elif isinstance(ucs.device, EMMADevice):
             entities_to_add.extend(create_emma_entities(ucs))
         elif isinstance(ucs.device, SChargerDevice):

--- a/strings.json
+++ b/strings.json
@@ -26,8 +26,16 @@
                     "enable_parameter_configuration": "Advanced: elevate permissions",
                     "host": "Host",
                     "port": "Port",
+                    "sensor_profile": "Sensor profile",
                     "slave_ids": "Slave IDs: AUTO for auto-discovery, otherwise a comma separated list"
                 }
+            },
+            "setup_sensor_profile_custom": {
+                "data": {
+                    "sensor_groups": "Sensor groups"
+                },
+                "description": "Select which groups should be enabled for custom profile mode.",
+                "title": "Custom Sensor Groups"
             },
             "setup_serial": {
                 "data": {

--- a/strings.json
+++ b/strings.json
@@ -32,9 +32,10 @@
             },
             "setup_sensor_profile_custom": {
                 "data": {
+                    "sensor_group_preset": "Quick selection",
                     "sensor_groups": "Sensor groups"
                 },
-                "description": "Select which groups should be enabled for custom profile mode.",
+                "description": "Choose a quick preset or manually select which groups should be enabled for custom profile mode.",
                 "title": "Custom Sensor Groups"
             },
             "setup_serial": {

--- a/translations/de.json
+++ b/translations/de.json
@@ -32,9 +32,10 @@
             },
             "setup_sensor_profile_custom": {
                 "data": {
+                    "sensor_group_preset": "Schnellauswahl",
                     "sensor_groups": "Sensorgruppen"
                 },
-                "description": "Waehlen Sie aus, welche Sensorgruppen im benutzerdefinierten Profil aktiv sein sollen.",
+                "description": "Waehlen Sie eine Schnellauswahl oder legen Sie die Sensorgruppen im benutzerdefinierten Profil manuell fest.",
                 "title": "Benutzerdefinierte Sensorgruppen"
             },
             "setup_serial": {

--- a/translations/de.json
+++ b/translations/de.json
@@ -26,8 +26,16 @@
                     "enable_parameter_configuration": "Fortgeschritten: Berechtigungen erhöhen",
                     "host": "Host",
                     "port": "Port",
+                    "sensor_profile": "Sensorprofil",
                     "slave_ids": "Slave-IDs: AUTO für automatische Entdeckung, sonst eine kommaseparierte Liste"
                 }
+            },
+            "setup_sensor_profile_custom": {
+                "data": {
+                    "sensor_groups": "Sensorgruppen"
+                },
+                "description": "Waehlen Sie aus, welche Sensorgruppen im benutzerdefinierten Profil aktiv sein sollen.",
+                "title": "Benutzerdefinierte Sensorgruppen"
             },
             "setup_serial": {
                 "data": {

--- a/translations/en.json
+++ b/translations/en.json
@@ -26,8 +26,16 @@
                     "enable_parameter_configuration": "Advanced: elevate permissions",
                     "host": "Host",
                     "port": "Port",
+                    "sensor_profile": "Sensor profile",
                     "slave_ids": "Slave IDs: AUTO for auto-discovery, otherwise a comma separated list"
                 }
+            },
+            "setup_sensor_profile_custom": {
+                "data": {
+                    "sensor_groups": "Sensor groups"
+                },
+                "description": "Select which groups should be enabled for custom profile mode.",
+                "title": "Custom Sensor Groups"
             },
             "setup_serial": {
                 "data": {

--- a/translations/en.json
+++ b/translations/en.json
@@ -32,9 +32,10 @@
             },
             "setup_sensor_profile_custom": {
                 "data": {
+                    "sensor_group_preset": "Quick selection",
                     "sensor_groups": "Sensor groups"
                 },
-                "description": "Select which groups should be enabled for custom profile mode.",
+                "description": "Choose a quick preset or manually select which groups should be enabled for custom profile mode.",
                 "title": "Custom Sensor Groups"
             },
             "setup_serial": {


### PR DESCRIPTION
## Summary

This PR improves stability for Huawei SDongle installations by adding profile-based sensor loading and a resilient initialization path.

The changes were implemented by Codex.
In our live setup, we are currently using `Normal (recommended)` and it is working.

## Problem observed

During setup on SDongle (`192.168.0.xxx:502`, slave IDs `1,2`), config flow often failed with:

- `Unexpected exception while connecting via TCP`
- `TimeoutError: Response timeout after 10 seconds for transaction ...`
- timeout occurring while reading optimizer-related register `NB_OPTIMIZERS`
- in related probing runs, optimizer paths also showed `exception_code=6` (`Slave Device Busy`)

At the same time, core PV/meter/battery values were readable and stable.

Can be a similar problem than described here: https://community.home-assistant.io/t/huawei-solar-unexpected-error/962595

## What this PR changes

- Adds sensor profiles in setup:
  - `Minimum (stable core values)`
  - `Normal (recommended)`
  - `All values (full)`
  - `Custom (choose groups)`

- Adds quick presets in Custom mode:
  - `Minimum`
  - `Normal`
  - `All values`
  - `Manual selection`

- Uses profile/group selection to control which sensor groups are created/read.
- Adds resilient SUN2000 init behavior so optimizer probing does not abort the whole setup when optimizer detail is not requested.

## Result in our case

- Setup now succeeds with `Normal (recommended)`.
- This directly addresses the timeout/failure pattern we observed around optimizer probing.

<img width="1572" height="878" alt="1" src="https://github.com/user-attachments/assets/5c9dd47e-b341-465a-bac1-cd3ec746ba59" />

![2](https://github.com/user-attachments/assets/23589599-4ae7-4bb6-ac70-45f35d3dab1f)

