### PR TITLE
Add GRID_FREQUENCY sensor

### DIFF
--- a/sensor.py
+++ b/sensor.py
@@ -204,6 +204,13 @@ INVERTER_SENSOR_DESCRIPTIONS: tuple[HuaweiSolarSensorEntityDescription, ...] = (
         entity_registry_enabled_default=False,
     ),
     HuaweiSolarSensorEntityDescription(
+        key=rn.GRID_FREQUENCY,
+        native_unit_of_measurement=UnitOfFrequency.HERTZ,
+        device_class=SensorDeviceClass.FREQUENCY,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_registry_enabled_default=False,
+    ),
+    HuaweiSolarSensorEntityDescription(
         key=rn.EFFICIENCY,
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,


### PR DESCRIPTION
Adding GRID frequency sensor that was removed during Huawei Solar v2 migration.
Code tested on latest 2.0.5 release. There is no other frequency sensor in the integration.