### PR TITLE
Add power-meter device support for SmartLogger setups

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -8,6 +8,7 @@ from huawei_solar import (
     EMMADevice,
     HuaweiSolarException,
     InvalidCredentials,
+    MeterDevice,
     SChargerDevice,
     SDongleDevice,
     SmartLoggerDevice,
@@ -411,6 +412,7 @@ async def _setup_inverter_device_data(
 
 DEVICE_CLASS_TO_TRANSLATION_KEY: dict[type[HuaweiSolarDevice], str] = {
     EMMADevice: "emma",
+    MeterDevice: "power_meter",
     SChargerDevice: "charger",
     SDongleDevice: "sdongle",
     SmartLoggerDevice: "smartlogger",

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,7 @@
     "documentation": "https://github.com/wlcrs/huawei_solar/wiki",
     "issue_tracker": "https://github.com/wlcrs/huawei_solar/issues",
     "requirements": [
-        "huawei-solar>=3.0.4"
+        "huawei-solar>=3.0.5"
     ],
     "codeowners": [
         "@wlcrs"

--- a/sensor.py
+++ b/sensor.py
@@ -7,6 +7,7 @@ from typing import Any
 from huawei_solar import (
     EMMADevice,
     HuaweiSolarDevice,
+    MeterDevice,
     SChargerDevice,
     SDongleDevice,
     SmartLoggerDevice,
@@ -2020,6 +2021,170 @@ def create_sdongle_entities(
     ]
 
 
+METER_SENSOR_DESCRIPTIONS: tuple[HuaweiSolarSensorEntityDescription, ...] = (
+    HuaweiSolarSensorEntityDescription(
+        key=rn.SMARTLOGGER_EXTERNAL_METER_ACTIVE_POWER,
+        translation_key="meter_active_power",
+        native_unit_of_measurement=UnitOfPower.KILO_WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    HuaweiSolarSensorEntityDescription(
+        key=rn.SMARTLOGGER_EXTERNAL_METER_REACTIVE_POWER,
+        translation_key="meter_reactive_power",
+        native_unit_of_measurement=UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE,
+        device_class=SensorDeviceClass.REACTIVE_POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    HuaweiSolarSensorEntityDescription(
+        key=rn.SMARTLOGGER_EXTERNAL_METER_APPARENT_POWER,
+        translation_key="meter_apparent_power",
+        native_unit_of_measurement=UnitOfApparentPower.VOLT_AMPERE,
+        device_class=SensorDeviceClass.APPARENT_POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    HuaweiSolarSensorEntityDescription(
+        key=rn.SMARTLOGGER_EXTERNAL_METER_POWER_FACTOR,
+        translation_key="meter_power_factor",
+        device_class=SensorDeviceClass.POWER_FACTOR,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    HuaweiSolarSensorEntityDescription(
+        key=rn.SMARTLOGGER_EXTERNAL_METER_PHASE_A_VOLTAGE,
+        translation_key="meter_phase_a_voltage",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    HuaweiSolarSensorEntityDescription(
+        key=rn.SMARTLOGGER_EXTERNAL_METER_PHASE_B_VOLTAGE,
+        translation_key="meter_phase_b_voltage",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    HuaweiSolarSensorEntityDescription(
+        key=rn.SMARTLOGGER_EXTERNAL_METER_PHASE_C_VOLTAGE,
+        translation_key="meter_phase_c_voltage",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    HuaweiSolarSensorEntityDescription(
+        key=rn.SMARTLOGGER_EXTERNAL_METER_A_B_LINE_VOLTAGE,
+        translation_key="meter_a_b_line_voltage",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_registry_enabled_default=False,
+    ),
+    HuaweiSolarSensorEntityDescription(
+        key=rn.SMARTLOGGER_EXTERNAL_METER_B_C_LINE_VOLTAGE,
+        translation_key="meter_b_c_line_voltage",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_registry_enabled_default=False,
+    ),
+    HuaweiSolarSensorEntityDescription(
+        key=rn.SMARTLOGGER_EXTERNAL_METER_C_A_LINE_VOLTAGE,
+        translation_key="meter_c_a_line_voltage",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_registry_enabled_default=False,
+    ),
+    HuaweiSolarSensorEntityDescription(
+        key=rn.SMARTLOGGER_EXTERNAL_METER_PHASE_A_CURRENT,
+        translation_key="meter_phase_a_current",
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        device_class=SensorDeviceClass.CURRENT,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    HuaweiSolarSensorEntityDescription(
+        key=rn.SMARTLOGGER_EXTERNAL_METER_PHASE_B_CURRENT,
+        translation_key="meter_phase_b_current",
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        device_class=SensorDeviceClass.CURRENT,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    HuaweiSolarSensorEntityDescription(
+        key=rn.SMARTLOGGER_EXTERNAL_METER_PHASE_C_CURRENT,
+        translation_key="meter_phase_c_current",
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        device_class=SensorDeviceClass.CURRENT,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    HuaweiSolarSensorEntityDescription(
+        key=rn.SMARTLOGGER_EXTERNAL_METER_PHASE_A_ACTIVE_POWER,
+        translation_key="meter_phase_a_active_power",
+        native_unit_of_measurement=UnitOfPower.KILO_WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_registry_enabled_default=False,
+    ),
+    HuaweiSolarSensorEntityDescription(
+        key=rn.SMARTLOGGER_EXTERNAL_METER_PHASE_B_ACTIVE_POWER,
+        translation_key="meter_phase_b_active_power",
+        native_unit_of_measurement=UnitOfPower.KILO_WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_registry_enabled_default=False,
+    ),
+    HuaweiSolarSensorEntityDescription(
+        key=rn.SMARTLOGGER_EXTERNAL_METER_PHASE_C_ACTIVE_POWER,
+        translation_key="meter_phase_c_active_power",
+        native_unit_of_measurement=UnitOfPower.KILO_WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_registry_enabled_default=False,
+    ),
+    HuaweiSolarSensorEntityDescription(
+        key=rn.SMARTLOGGER_EXTERNAL_METER_POSITIVE_ACTIVE_ELECTRICITY_TOTAL,
+        translation_key="meter_positive_active_energy",
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+    ),
+    HuaweiSolarSensorEntityDescription(
+        key=rn.SMARTLOGGER_EXTERNAL_METER_NEGATIVE_ACTIVE_ELECTRICITY,
+        translation_key="meter_negative_active_energy",
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+    ),
+    HuaweiSolarSensorEntityDescription(
+        key=rn.SMARTLOGGER_EXTERNAL_METER_TOTAL_ACTIVE_ELECTRICITY,
+        translation_key="meter_total_active_energy",
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL,
+        entity_registry_enabled_default=False,
+    ),
+    HuaweiSolarSensorEntityDescription(
+        key=rn.SMARTLOGGER_EXTERNAL_METER_TOTAL_REACTIVE_ELECTRICITY,
+        translation_key="meter_total_reactive_energy",
+        native_unit_of_measurement="kvarh",
+        state_class=SensorStateClass.TOTAL,
+        entity_registry_enabled_default=False,
+    ),
+)
+
+
+def create_meter_entities(
+    ucs: HuaweiSolarDeviceData,
+) -> list["HuaweiSolarSensorEntity"]:
+    """Create power-meter sensor entities."""
+    assert isinstance(ucs.device, MeterDevice)
+
+    return [
+        HuaweiSolarSensorEntity(
+            ucs.update_coordinator, entity_description, ucs.device_info
+        )
+        for entity_description in METER_SENSOR_DESCRIPTIONS
+    ]
+
+
 def create_smartlogger_entities(
     ucs: HuaweiSolarDeviceData,
 ) -> list["HuaweiSolarSensorEntity"]:
@@ -2056,6 +2221,8 @@ async def async_setup_entry(
             entities_to_add.extend(create_charger_entities(ucs))
         elif isinstance(ucs.device, SDongleDevice):
             entities_to_add.extend(create_sdongle_entities(ucs))
+        elif isinstance(ucs.device, MeterDevice):
+            entities_to_add.extend(create_meter_entities(ucs))
         elif isinstance(ucs.device, SmartLoggerDevice):
             entities_to_add.extend(create_smartlogger_entities(ucs))
 

--- a/strings.json
+++ b/strings.json
@@ -453,8 +453,68 @@
             "load_power": {
                 "name": "Load power"
             },
+            "meter_a_b_line_voltage": {
+                "name": "Line voltage A-B"
+            },
+            "meter_active_power": {
+                "name": "Active power"
+            },
+            "meter_apparent_power": {
+                "name": "Apparent power"
+            },
+            "meter_b_c_line_voltage": {
+                "name": "Line voltage B-C"
+            },
+            "meter_c_a_line_voltage": {
+                "name": "Line voltage C-A"
+            },
+            "meter_negative_active_energy": {
+                "name": "Negative active energy"
+            },
+            "meter_phase_a_active_power": {
+                "name": "Phase A active power"
+            },
+            "meter_phase_a_current": {
+                "name": "Phase A current"
+            },
+            "meter_phase_a_voltage": {
+                "name": "Phase A voltage"
+            },
+            "meter_phase_b_active_power": {
+                "name": "Phase B active power"
+            },
+            "meter_phase_b_current": {
+                "name": "Phase B current"
+            },
+            "meter_phase_b_voltage": {
+                "name": "Phase B voltage"
+            },
+            "meter_phase_c_active_power": {
+                "name": "Phase C active power"
+            },
+            "meter_phase_c_current": {
+                "name": "Phase C current"
+            },
+            "meter_phase_c_voltage": {
+                "name": "Phase C voltage"
+            },
+            "meter_positive_active_energy": {
+                "name": "Positive active energy"
+            },
+            "meter_power_factor": {
+                "name": "Power factor"
+            },
+            "meter_reactive_power": {
+                "name": "Reactive power"
+            },
             "meter_status": {
                 "name": "Meter status"
+            },
+            "meter_total_active_energy": {
+                "name": "Total active energy"
+            },
+            "meter_total_reactive_energy": {
+                "name": "Total reactive energy"
             },
             "monthly_yield_energy": {
                 "name": "Monthly yield"

--- a/translations/en.json
+++ b/translations/en.json
@@ -453,8 +453,68 @@
             "load_power": {
                 "name": "Load power"
             },
+            "meter_a_b_line_voltage": {
+                "name": "Line voltage A-B"
+            },
+            "meter_active_power": {
+                "name": "Active power"
+            },
+            "meter_apparent_power": {
+                "name": "Apparent power"
+            },
+            "meter_b_c_line_voltage": {
+                "name": "Line voltage B-C"
+            },
+            "meter_c_a_line_voltage": {
+                "name": "Line voltage C-A"
+            },
+            "meter_negative_active_energy": {
+                "name": "Negative active energy"
+            },
+            "meter_phase_a_active_power": {
+                "name": "Phase A active power"
+            },
+            "meter_phase_a_current": {
+                "name": "Phase A current"
+            },
+            "meter_phase_a_voltage": {
+                "name": "Phase A voltage"
+            },
+            "meter_phase_b_active_power": {
+                "name": "Phase B active power"
+            },
+            "meter_phase_b_current": {
+                "name": "Phase B current"
+            },
+            "meter_phase_b_voltage": {
+                "name": "Phase B voltage"
+            },
+            "meter_phase_c_active_power": {
+                "name": "Phase C active power"
+            },
+            "meter_phase_c_current": {
+                "name": "Phase C current"
+            },
+            "meter_phase_c_voltage": {
+                "name": "Phase C voltage"
+            },
+            "meter_positive_active_energy": {
+                "name": "Positive active energy"
+            },
+            "meter_power_factor": {
+                "name": "Power factor"
+            },
+            "meter_reactive_power": {
+                "name": "Reactive power"
+            },
             "meter_status": {
                 "name": "Meter status"
+            },
+            "meter_total_active_energy": {
+                "name": "Total active energy"
+            },
+            "meter_total_reactive_energy": {
+                "name": "Total reactive energy"
             },
             "monthly_yield_energy": {
                 "name": "Monthly yield"


### PR DESCRIPTION
## Summary

Surfaces a power meter connected to a Huawei SmartLogger over RS485 as
a "Power meter" device in Home Assistant, with full telemetry sensors,
on top of [huawei-solar 3.0.5][lib-release] (wlcrs/huawei-solar-lib
PRs #31 and #32, which added the underlying `MeterDevice` class).

[lib-release]: https://github.com/wlcrs/huawei-solar-lib/releases/tag/v3.0.5

Tested on a **SmartLogger3000A** acting as Modbus TCP gateway in front
of a DTSU666-shaped meter (slave 11), 4× SUN2000 inverters, and a
LUNA 2000 battery.

## Changes

- `manifest.json`: bump the `huawei-solar` requirement to **>=3.0.5**.
- `__init__.py`: import `MeterDevice` and map it to the existing
  `power_meter` translation key in `DEVICE_CLASS_TO_TRANSLATION_KEY`.
- `sensor.py`: new `METER_SENSOR_DESCRIPTIONS` plus
  `create_meter_entities`, wired into `async_setup_entry`. 20 entity
  descriptions covering the SmartLogger external-meter register block
  (`32260` – `32361`):
  - **Enabled by default**: active power, reactive power, apparent
    power, power factor, phase A/B/C voltage and current, positive
    active energy, negative active energy.
  - **Disabled by default (opt-in)**: A-B / B-C / C-A line voltages,
    per-phase active power, total active / reactive energy.
- `strings.json` + `translations/en.json`: new `meter_*` entity
  translations for the descriptions above.

The device translation key `power_meter` already existed; no new
device translation is needed.

## Reproduction / evidence

With this PR applied and `huawei-solar` 3.0.5 installed, Reconfigure
in **AUTO** mode connects to all slaves the SmartLogger reports,
including the meter:

> *Successfully connected to **SmartLogger** (serial number: 102120056473)
> on slave ID(s): 0, **11**, 3, 12, 2, 4.*

The resulting "Power meter" device:

| Sensor                | Reading (sample)     |
| --------------------- | -------------------- |
| Active power          | 0.02 kW              |
| Reactive power        | -0.37 kvar           |
| Apparent power        | 0 VA                 |
| Power factor          | -0.056               |
| Phase A/B/C voltage   | 242 V / 241 V / 241 V|
| Phase A/B/C current   | 0.70 A / 0.50 A / 0.40 A |
| Positive active energy| 34,316.06 kWh        |
| Negative active energy| 74,968.45 kWh        |

(Plus seven opt-in sensors: line voltages, per-phase active power,
total active/reactive energy.)

## Related issues / PRs

- wlcrs/huawei-solar-lib PR #31 — *Honour wrapped ReadException and
  detect SmartLogger via ESN register* (merged).
- wlcrs/huawei-solar-lib PR #32 — *Detect power meters connected via a
  SmartLogger* (cherry-picked into develop, shipped in 3.0.5).
- Downstream report this PR closes the loop on: #1342 — *"[Bug]:
  SmartLogger 3000A meter not discovered + IllegalDataValueError with
  elevated permissions"*.

## Test plan

- [x] Manifest's `huawei-solar` requirement bumped to a released version (3.0.5).
- [x] `python -m py_compile __init__.py sensor.py` — no syntax errors.
- [x] `json.load` parses `manifest.json`, `strings.json`, `translations/en.json`.
- [x] Re-configure existing entry in AUTO mode picks up the meter slave (live).
- [x] Meter sensors populate with values consistent with the SmartLogger WebUI.
- [ ] CI / HACS validation (relies on maintainer running the workflows).
