### PR TITLE
Added the setting to change the update interval.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,5 @@
-"""The Huawei Solar integration."""
-
 import logging
+from datetime import timedelta
 
 from huawei_solar import (
     ConnectionException,
@@ -27,6 +26,7 @@ from homeassistant.const import (
     CONF_HOST,
     CONF_PASSWORD,
     CONF_PORT,
+    CONF_SCAN_INTERVAL,
     CONF_USERNAME,
     Platform,
 )
@@ -201,10 +201,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: HuaweiSolarConfigEntry) 
             await primary_device.stop()
         raise
 
+    entry.async_on_unload(entry.add_update_listener(async_update_options))
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     await async_setup_services(hass, entry)
 
     return True
+
+
+async def async_update_options(
+    hass: HomeAssistant, entry: HuaweiSolarConfigEntry
+) -> None:
+    """Update options."""
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_unload_entry(
@@ -241,6 +250,7 @@ async def _setup_inverter_device_data(
     device: SUN2000Device,
     connecting_inverter_device_id: tuple[str, str] | None,
 ) -> HuaweiSolarInverterData:
+    scan_interval = timedelta(seconds=entry.options.get(CONF_SCAN_INTERVAL, 30))
     device_registry = dr.async_get(hass)
 
     inverter_device_info = DeviceInfo(
@@ -268,7 +278,7 @@ async def _setup_inverter_device_data(
         _LOGGER,
         device=device,
         name=f"{device.serial_number}_data_update_coordinator",
-        update_interval=INVERTER_UPDATE_INTERVAL,
+        update_interval=scan_interval,
     )
 
     # Add power meter device if a power meter is detected
@@ -285,7 +295,7 @@ async def _setup_inverter_device_data(
             _LOGGER,
             device=device,
             name=f"{device.serial_number}_power_meter_data_update_coordinator",
-            update_interval=POWER_METER_UPDATE_INTERVAL,
+            update_interval=scan_interval,
         )
     else:
         power_meter_device_info = None
@@ -308,7 +318,7 @@ async def _setup_inverter_device_data(
             _LOGGER,
             device=device,
             name=f"{device.serial_number}_battery_data_update_coordinator",
-            update_interval=ENERGY_STORAGE_UPDATE_INTERVAL,
+            update_interval=scan_interval,
         )
     else:
         battery_device_info = None
@@ -428,6 +438,7 @@ async def _setup_device_data(
     if isinstance(device, SUN2000Device):
         return await _setup_inverter_device_data(hass, entry, device, None)
 
+    scan_interval = timedelta(seconds=entry.options.get(CONF_SCAN_INTERVAL, 30))
     device_registry = dr.async_get(hass)
 
     sw_version = getattr(device, "software_version", None)
@@ -456,7 +467,7 @@ async def _setup_device_data(
         _LOGGER,
         device=device,
         name=f"{device.serial_number}_data_update_coordinator",
-        update_interval=INVERTER_UPDATE_INTERVAL,
+        update_interval=scan_interval,
     )
 
     if entry.data.get(CONF_ENABLE_PARAMETER_CONFIGURATION, False):

--- a/config_flow.py
+++ b/config_flow.py
@@ -36,9 +36,11 @@ from homeassistant.const import (
     CONF_HOST,
     CONF_PASSWORD,
     CONF_PORT,
+    CONF_SCAN_INTERVAL,
     CONF_TYPE,
     CONF_USERNAME,
 )
+from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 
 from .const import (
@@ -1394,6 +1396,14 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_create_entry(title=inverter_info["model_name"], data=data)
 
+    @staticmethod
+    @callback
+    def async_get_options_flow(
+        config_entry: config_entries.ConfigEntry,
+    ) -> HuaweiSolarOptionsFlowHandler:
+        """Get the options flow for this handler."""
+        return HuaweiSolarOptionsFlowHandler()
+
 
 class UnitIdsParseException(Exception):
     """Error while parsing the unit id's."""
@@ -1406,3 +1416,28 @@ class DeviceException(Exception):
         """Initialize DeviceException."""
         super().__init__(message)
         self.unit_id = unit_id
+
+
+class HuaweiSolarOptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle Huawei Solar options."""
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Manage the options."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        options = self.config_entry.options
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_SCAN_INTERVAL,
+                        default=options.get(CONF_SCAN_INTERVAL, 30),
+                    ): vol.All(vol.Coerce(int), vol.Range(min=5)),
+                }
+            ),
+        )

--- a/strings.json
+++ b/strings.json
@@ -108,6 +108,15 @@
             }
         }
     },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "scan_interval": "Update interval (seconds)"
+                }
+            }
+        }
+    },
     "device": {
         "battery_1": {
             "name": "Battery 1"

--- a/translations/bg.json
+++ b/translations/bg.json
@@ -108,6 +108,15 @@
             }
         }
     },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "scan_interval": "Интервал на опресняване (секунди)"
+                }
+            }
+        }
+    },
     "device": {
         "battery_1": {
             "name": "Battery 1"

--- a/translations/ca.json
+++ b/translations/ca.json
@@ -108,6 +108,15 @@
             }
         }
     },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "scan_interval": "Interval d'actualització (segons)"
+                }
+            }
+        }
+    },
     "device": {
         "battery_1": {
             "name": "Battery 1"

--- a/translations/ca_ES.json
+++ b/translations/ca_ES.json
@@ -50,6 +50,15 @@
             }
         }
     },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "scan_interval": "Interval d'actualització (segons)"
+                }
+            }
+        }
+    },
     "entity": {
         "button": {
             "stop_forcible_charge": {

--- a/translations/de.json
+++ b/translations/de.json
@@ -108,6 +108,15 @@
             }
         }
     },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "scan_interval": "Aktualisierungsintervall (Sekunden)"
+                }
+            }
+        }
+    },
     "device": {
         "battery_1": {
             "name": "Batterie 1"

--- a/translations/en.json
+++ b/translations/en.json
@@ -108,6 +108,15 @@
             }
         }
     },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "scan_interval": "Update interval (seconds)"
+                }
+            }
+        }
+    },
     "device": {
         "battery_1": {
             "name": "Battery 1"

--- a/translations/es.json
+++ b/translations/es.json
@@ -108,6 +108,15 @@
             }
         }
     },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "scan_interval": "Intervalo de actualización (segundos)"
+                }
+            }
+        }
+    },
     "device": {
         "battery_1": {
             "name": "Batería 1"

--- a/translations/es_ES.json
+++ b/translations/es_ES.json
@@ -50,6 +50,15 @@
             }
         }
     },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "scan_interval": "Intervalo de actualización (segundos)"
+                }
+            }
+        }
+    },
     "entity": {
         "button": {
             "stop_forcible_charge": {

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -108,6 +108,15 @@
             }
         }
     },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "scan_interval": "Intervalle de mise à jour (secondes)"
+                }
+            }
+        }
+    },
     "device": {
         "battery_1": {
             "name": "Batterie 1"

--- a/translations/hu.json
+++ b/translations/hu.json
@@ -108,6 +108,15 @@
             }
         }
     },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "scan_interval": "Frissítési időköz (másodperc)"
+                }
+            }
+        }
+    },
     "device": {
         "battery_1": {
             "name": "Battery 1"

--- a/translations/it.json
+++ b/translations/it.json
@@ -108,6 +108,15 @@
             }
         }
     },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "scan_interval": "Intervallo di aggiornamento (secondi)"
+                }
+            }
+        }
+    },
     "device": {
         "battery_1": {
             "name": "Batteria 1"

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -108,6 +108,15 @@
             }
         }
     },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "scan_interval": "Update-interval (seconden)"
+                }
+            }
+        }
+    },
     "device": {
         "battery_1": {
             "name": "Batterij 1"

--- a/translations/pl.json
+++ b/translations/pl.json
@@ -108,6 +108,15 @@
             }
         }
     },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "scan_interval": "Interwał aktualizacji (sekundy)"
+                }
+            }
+        }
+    },
     "device": {
         "battery_1": {
             "name": "Akumulator 1"

--- a/translations/pt-BR.json
+++ b/translations/pt-BR.json
@@ -61,6 +61,15 @@
             }
         }
     },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "scan_interval": "Intervalo de atualização (segundos)"
+                }
+            }
+        }
+    },
     "device": {
         "battery_1": {
             "name": "Battery 1"

--- a/translations/pt.json
+++ b/translations/pt.json
@@ -108,6 +108,15 @@
             }
         }
     },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "scan_interval": "Intervalo de atualização (segundos)"
+                }
+            }
+        }
+    },
     "device": {
         "battery_1": {
             "name": "Battery 1"

--- a/translations/ro.json
+++ b/translations/ro.json
@@ -108,6 +108,15 @@
             }
         }
     },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "scan_interval": "Interval de actualizare (secunde)"
+                }
+            }
+        }
+    },
     "device": {
         "battery_1": {
             "name": "Battery 1"

--- a/translations/ru.json
+++ b/translations/ru.json
@@ -108,6 +108,15 @@
             }
         }
     },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "scan_interval": "Интервал обновления (секунды)"
+                }
+            }
+        }
+    },
     "device": {
         "battery_1": {
             "name": "Батарея 1"

--- a/translations/sv.json
+++ b/translations/sv.json
@@ -108,6 +108,15 @@
             }
         }
     },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "scan_interval": "Uppdateringsintervall (sekunder)"
+                }
+            }
+        }
+    },
     "device": {
         "battery_1": {
             "name": "Battery 1"

--- a/translations/ur.json
+++ b/translations/ur.json
@@ -108,6 +108,15 @@
             }
         }
     },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "scan_interval": "اپ ڈیٹ کا وقفہ (سیکنڈ)"
+                }
+            }
+        }
+    },
     "device": {
         "battery_1": {
             "name": "Battery 1"


### PR DESCRIPTION
This PR adds the ability for users to customize the data update interval (scan frequency) directly from the integration's options menu in Home Assistant. 

Previously, the data polling rate was hardcoded to a fixed 30-second interval. With this change, users can safely adjust this rate to better suit their network setup and Modbus bandwidth limits.

