### PR TITLE
Add options to control the timeout and polling rate of different kind of entities

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,7 @@
 """The Huawei Solar integration."""
 
 import logging
+from datetime import timedelta
 
 from huawei_solar import (
     ConnectionException,
@@ -37,14 +38,23 @@ from homeassistant.helpers.device_registry import DeviceInfo
 
 from .const import (
     CONF_ENABLE_PARAMETER_CONFIGURATION,
+    CONF_ENERGY_STORAGE_UPDATE_INTERVAL,
+    CONF_INVERTER_UPDATE_INTERVAL,
     CONF_SLAVE_IDS,
+    CONF_POWER_METER_UPDATE_INTERVAL,
+    CONF_TCP_TIMEOUT,
+    CONF_UPDATE_TIMEOUT,
+    CONF_WAIT_BETWEEN_REQUESTS,
     CONFIGURATION_UPDATE_INTERVAL,
     DATA_DEVICE_DATAS,
+    DEFAULT_TCP_TIMEOUT,
+    DEFAULT_WAIT_BETWEEN_REQUESTS,
     DOMAIN,
     ENERGY_STORAGE_UPDATE_INTERVAL,
     INVERTER_UPDATE_INTERVAL,
     OPTIMIZER_UPDATE_INTERVAL,
     POWER_METER_UPDATE_INTERVAL,
+    UPDATE_TIMEOUT,
 )
 from .services import async_setup_services
 from .types import (
@@ -66,6 +76,25 @@ PLATFORMS: list[Platform] = [
     Platform.SENSOR,
     Platform.SWITCH,
 ]
+
+
+def _get_seconds_option(
+    entry: ConfigEntry, key: str, default: timedelta
+) -> timedelta:
+    """Return an entry option stored in seconds as a timedelta."""
+    return timedelta(seconds=entry.options.get(key, int(default.total_seconds())))
+
+
+def _get_update_timeout(entry: ConfigEntry) -> timedelta:
+    """Return the configured coordinator update timeout."""
+    return _get_seconds_option(entry, CONF_UPDATE_TIMEOUT, UPDATE_TIMEOUT)
+
+
+async def _async_options_updated(
+    hass: HomeAssistant, entry: HuaweiSolarConfigEntry
+) -> None:
+    """Reload the integration when options are changed."""
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: HuaweiSolarConfigEntry) -> bool:
@@ -96,15 +125,23 @@ async def async_setup_entry(hass: HomeAssistant, entry: HuaweiSolarConfigEntry) 
         #  │ SLAVE X │     │ SLAVE Y │    │SLAVE ...│
         #  └─────────┘     └─────────┘    └─────────┘
 
+        wait_between_requests = entry.options.get(
+            CONF_WAIT_BETWEEN_REQUESTS, DEFAULT_WAIT_BETWEEN_REQUESTS
+        )
+
         if entry.data[CONF_HOST] is None:
             client = create_rtu_client(
-                port=entry.data[CONF_PORT], unit_id=entry.data[CONF_SLAVE_IDS][0]
+                port=entry.data[CONF_PORT],
+                unit_id=entry.data[CONF_SLAVE_IDS][0],
+                wait_between_requests=wait_between_requests,
             )
         else:
             client = create_tcp_client(
                 host=entry.data[CONF_HOST],
                 port=entry.data[CONF_PORT],
                 unit_id=entry.data[CONF_SLAVE_IDS][0],
+                timeout=entry.options.get(CONF_TCP_TIMEOUT, DEFAULT_TCP_TIMEOUT),
+                wait_between_requests=wait_between_requests,
             )
 
         primary_device = await create_device_instance(client)
@@ -202,6 +239,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: HuaweiSolarConfigEntry) 
         raise
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    entry.async_on_unload(entry.add_update_listener(_async_options_updated))
     await async_setup_services(hass, entry)
 
     return True
@@ -268,7 +306,10 @@ async def _setup_inverter_device_data(
         _LOGGER,
         device=device,
         name=f"{device.serial_number}_data_update_coordinator",
-        update_interval=INVERTER_UPDATE_INTERVAL,
+        update_interval=_get_seconds_option(
+            entry, CONF_INVERTER_UPDATE_INTERVAL, INVERTER_UPDATE_INTERVAL
+        ),
+        update_timeout=_get_update_timeout(entry),
     )
 
     # Add power meter device if a power meter is detected
@@ -285,7 +326,10 @@ async def _setup_inverter_device_data(
             _LOGGER,
             device=device,
             name=f"{device.serial_number}_power_meter_data_update_coordinator",
-            update_interval=POWER_METER_UPDATE_INTERVAL,
+            update_interval=_get_seconds_option(
+                entry, CONF_POWER_METER_UPDATE_INTERVAL, POWER_METER_UPDATE_INTERVAL
+            ),
+            update_timeout=_get_update_timeout(entry),
         )
     else:
         power_meter_device_info = None
@@ -308,7 +352,12 @@ async def _setup_inverter_device_data(
             _LOGGER,
             device=device,
             name=f"{device.serial_number}_battery_data_update_coordinator",
-            update_interval=ENERGY_STORAGE_UPDATE_INTERVAL,
+            update_interval=_get_seconds_option(
+                entry,
+                CONF_ENERGY_STORAGE_UPDATE_INTERVAL,
+                ENERGY_STORAGE_UPDATE_INTERVAL,
+            ),
+            update_timeout=_get_update_timeout(entry),
         )
     else:
         battery_device_info = None
@@ -456,7 +505,10 @@ async def _setup_device_data(
         _LOGGER,
         device=device,
         name=f"{device.serial_number}_data_update_coordinator",
-        update_interval=INVERTER_UPDATE_INTERVAL,
+        update_interval=_get_seconds_option(
+            entry, CONF_INVERTER_UPDATE_INTERVAL, INVERTER_UPDATE_INTERVAL
+        ),
+        update_timeout=_get_update_timeout(entry),
     )
 
     if entry.data.get(CONF_ENABLE_PARAMETER_CONFIGURATION, False):

--- a/config_flow.py
+++ b/config_flow.py
@@ -43,16 +43,39 @@ import homeassistant.helpers.config_validation as cv
 
 from .const import (
     CONF_ENABLE_PARAMETER_CONFIGURATION,
+    CONF_ENERGY_STORAGE_UPDATE_INTERVAL,
+    CONF_INVERTER_UPDATE_INTERVAL,
+    CONF_MONITORING_UPDATE_INTERVAL,
+    CONF_POWER_METER_UPDATE_INTERVAL,
+    CONF_REALTIME_POWER_UPDATE_INTERVAL,
     CONF_SLAVE_IDS,
+    CONF_SPLIT_POWER_POLLING,
+    CONF_TCP_TIMEOUT,
+    CONF_UPDATE_TIMEOUT,
+    CONF_WAIT_BETWEEN_REQUESTS,
     DEFAULT_PORT,
     DEFAULT_SERIAL_SLAVE_ID,
+    DEFAULT_SPLIT_POWER_POLLING,
+    DEFAULT_TCP_TIMEOUT,
     DEFAULT_USERNAME,
+    DEFAULT_WAIT_BETWEEN_REQUESTS,
     DOMAIN,
+    ENERGY_STORAGE_UPDATE_INTERVAL,
+    INVERTER_UPDATE_INTERVAL,
+    MONITORING_UPDATE_INTERVAL,
+    POWER_METER_UPDATE_INTERVAL,
+    REALTIME_POWER_UPDATE_INTERVAL,
+    UPDATE_TIMEOUT,
 )
 
 _LOGGER = logging.getLogger(__name__)
 
 CONF_MANUAL_PATH = "Enter Manually"
+
+
+def _seconds(timedelta_value) -> int:
+    """Return whole seconds from a timedelta."""
+    return int(timedelta_value.total_seconds())
 
 
 async def validate_serial_setup(port: str, unit_ids: list[int]) -> dict[str, Any]:
@@ -508,6 +531,13 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
     MINOR_VERSION = 1
+
+    @staticmethod
+    def async_get_options_flow(
+        _config_entry: config_entries.ConfigEntry,
+    ) -> config_entries.OptionsFlow:
+        """Create the options flow."""
+        return HuaweiSolarOptionsFlowHandler()
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -1393,6 +1423,87 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._abort_if_unique_id_configured(updates=data)
 
         return self.async_create_entry(title=inverter_info["model_name"], data=data)
+
+
+class HuaweiSolarOptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle Huawei Solar options."""
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Manage integration options."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        options = self.config_entry.options
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        CONF_TCP_TIMEOUT,
+                        default=options.get(CONF_TCP_TIMEOUT, DEFAULT_TCP_TIMEOUT),
+                    ): vol.All(vol.Coerce(int), vol.Range(min=1)),
+                    vol.Optional(
+                        CONF_WAIT_BETWEEN_REQUESTS,
+                        default=options.get(
+                            CONF_WAIT_BETWEEN_REQUESTS,
+                            DEFAULT_WAIT_BETWEEN_REQUESTS,
+                        ),
+                    ): vol.All(vol.Coerce(float), vol.Range(min=0)),
+                    vol.Optional(
+                        CONF_UPDATE_TIMEOUT,
+                        default=options.get(
+                            CONF_UPDATE_TIMEOUT,
+                            _seconds(UPDATE_TIMEOUT),
+                        ),
+                    ): vol.All(vol.Coerce(int), vol.Range(min=1)),
+                    vol.Optional(
+                        CONF_SPLIT_POWER_POLLING,
+                        default=options.get(
+                            CONF_SPLIT_POWER_POLLING,
+                            DEFAULT_SPLIT_POWER_POLLING,
+                        ),
+                    ): bool,
+                    vol.Optional(
+                        CONF_REALTIME_POWER_UPDATE_INTERVAL,
+                        default=options.get(
+                            CONF_REALTIME_POWER_UPDATE_INTERVAL,
+                            _seconds(REALTIME_POWER_UPDATE_INTERVAL),
+                        ),
+                    ): vol.All(vol.Coerce(int), vol.Range(min=1)),
+                    vol.Optional(
+                        CONF_MONITORING_UPDATE_INTERVAL,
+                        default=options.get(
+                            CONF_MONITORING_UPDATE_INTERVAL,
+                            _seconds(MONITORING_UPDATE_INTERVAL),
+                        ),
+                    ): vol.All(vol.Coerce(int), vol.Range(min=1)),
+                    vol.Optional(
+                        CONF_INVERTER_UPDATE_INTERVAL,
+                        default=options.get(
+                            CONF_INVERTER_UPDATE_INTERVAL,
+                            _seconds(INVERTER_UPDATE_INTERVAL),
+                        ),
+                    ): vol.All(vol.Coerce(int), vol.Range(min=1)),
+                    vol.Optional(
+                        CONF_POWER_METER_UPDATE_INTERVAL,
+                        default=options.get(
+                            CONF_POWER_METER_UPDATE_INTERVAL,
+                            _seconds(POWER_METER_UPDATE_INTERVAL),
+                        ),
+                    ): vol.All(vol.Coerce(int), vol.Range(min=1)),
+                    vol.Optional(
+                        CONF_ENERGY_STORAGE_UPDATE_INTERVAL,
+                        default=options.get(
+                            CONF_ENERGY_STORAGE_UPDATE_INTERVAL,
+                            _seconds(ENERGY_STORAGE_UPDATE_INTERVAL),
+                        ),
+                    ): vol.All(vol.Coerce(int), vol.Range(min=1)),
+                }
+            ),
+        )
 
 
 class UnitIdsParseException(Exception):

--- a/const.py
+++ b/const.py
@@ -15,6 +15,22 @@ CONF_ENABLE_PARAMETER_CONFIGURATION = "enable_parameter_configuration"
 DATA_DEVICE_DATAS = "device_datas"
 DATA_UPDATE_COORDINATORS = "update_coordinators"
 
+CONF_TCP_TIMEOUT = "tcp_timeout"
+CONF_WAIT_BETWEEN_REQUESTS = "wait_between_requests"
+CONF_SPLIT_POWER_POLLING = "split_power_polling"
+CONF_REALTIME_POWER_UPDATE_INTERVAL = "realtime_power_update_interval"
+CONF_MONITORING_UPDATE_INTERVAL = "monitoring_update_interval"
+CONF_INVERTER_UPDATE_INTERVAL = "inverter_update_interval"
+CONF_POWER_METER_UPDATE_INTERVAL = "power_meter_update_interval"
+CONF_ENERGY_STORAGE_UPDATE_INTERVAL = "energy_storage_update_interval"
+CONF_UPDATE_TIMEOUT = "update_timeout"
+
+DEFAULT_TCP_TIMEOUT = 10
+DEFAULT_WAIT_BETWEEN_REQUESTS = 0.05
+DEFAULT_SPLIT_POWER_POLLING = False
+
+REALTIME_POWER_UPDATE_INTERVAL = timedelta(seconds=30)
+MONITORING_UPDATE_INTERVAL = timedelta(seconds=30)
 INVERTER_UPDATE_INTERVAL = timedelta(seconds=30)
 POWER_METER_UPDATE_INTERVAL = timedelta(seconds=30)
 ENERGY_STORAGE_UPDATE_INTERVAL = timedelta(seconds=30)

--- a/sensor.py
+++ b/sensor.py
@@ -1,7 +1,9 @@
 """Support for Huawei inverter monitoring API."""
 
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
+from datetime import timedelta
+import logging
 from typing import Any
 
 from huawei_solar import (
@@ -46,7 +48,17 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DATA_DEVICE_DATAS
+from .const import (
+    CONF_MONITORING_UPDATE_INTERVAL,
+    CONF_REALTIME_POWER_UPDATE_INTERVAL,
+    CONF_SPLIT_POWER_POLLING,
+    CONF_UPDATE_TIMEOUT,
+    DATA_DEVICE_DATAS,
+    DEFAULT_SPLIT_POWER_POLLING,
+    MONITORING_UPDATE_INTERVAL,
+    REALTIME_POWER_UPDATE_INTERVAL,
+    UPDATE_TIMEOUT,
+)
 from .types import (
     HuaweiSolarConfigEntry,
     HuaweiSolarDeviceData,
@@ -61,6 +73,20 @@ from .update_coordinator import (
 )
 
 PARALLEL_UPDATES = 1
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _get_seconds_option(
+    options: Mapping[str, Any], key: str, default: timedelta
+) -> timedelta:
+    """Return an entry option stored in seconds as a timedelta."""
+    return timedelta(seconds=options.get(key, int(default.total_seconds())))
+
+
+def _get_split_power_polling(options: Mapping[str, Any]) -> bool:
+    """Return whether power sensors should use dedicated fast coordinators."""
+    return bool(options.get(CONF_SPLIT_POWER_POLLING, DEFAULT_SPLIT_POWER_POLLING))
 
 
 @dataclass(frozen=True)
@@ -87,6 +113,66 @@ class HuaweiSolarSensorEntityDescription(
     def context(self) -> HuaweiSolarEntityContext:
         """Context used by DataUpdateCoordinator."""
         return {"register_names": [rn.RegisterName(self.key.split("#")[0])]}
+
+
+REALTIME_INVERTER_REGISTERS = {
+    rn.INPUT_POWER,
+    rn.ACTIVE_POWER,
+}
+
+REALTIME_POWER_METER_REGISTERS = {
+    rn.POWER_METER_ACTIVE_POWER,
+    rn.ACTIVE_GRID_A_POWER,
+    rn.ACTIVE_GRID_B_POWER,
+    rn.ACTIVE_GRID_C_POWER,
+}
+
+REALTIME_ENERGY_STORAGE_REGISTERS = {
+    rn.STORAGE_CHARGE_DISCHARGE_POWER,
+    rn.STORAGE_UNIT_1_CHARGE_DISCHARGE_POWER,
+    rn.STORAGE_UNIT_2_CHARGE_DISCHARGE_POWER,
+}
+
+REALTIME_SDONGLE_REGISTERS = {
+    rn.SDONGLE_TOTAL_INPUT_POWER,
+    rn.SDONGLE_LOAD_POWER,
+    rn.SDONGLE_GRID_POWER,
+    rn.SDONGLE_TOTAL_BATTERY_POWER,
+    rn.SDONGLE_TOTAL_ACTIVE_POWER,
+}
+
+MONITORING_REGISTERS = {
+    rn.DEVICE_STATUS,
+    rn.STATE_1,
+    rn.STATE_2,
+    rn.STATE_3,
+    rn.ALARM_1,
+    rn.ALARM_2,
+    rn.ALARM_3,
+}
+
+
+def _register_name_from_key(key: str) -> rn.RegisterName:
+    """Get the underlying register name from an entity key."""
+    return rn.RegisterName(key.split("#")[0])
+
+
+def _select_sun2000_coordinator(
+    entity_description: HuaweiSolarSensorEntityDescription,
+    realtime_update_coordinator: HuaweiSolarUpdateCoordinator,
+    monitoring_update_coordinator: HuaweiSolarUpdateCoordinator,
+    default_update_coordinator: HuaweiSolarUpdateCoordinator,
+    realtime_registers: set[rn.RegisterName],
+) -> HuaweiSolarUpdateCoordinator:
+    """Route high-rate and monitoring sensors away from slow background polling."""
+    register_name = _register_name_from_key(entity_description.key)
+
+    if register_name in realtime_registers:
+        return realtime_update_coordinator
+    if register_name in MONITORING_REGISTERS:
+        return monitoring_update_coordinator
+
+    return default_update_coordinator
 
 
 # Every list in this file describes a group of entities which are related to each other.
@@ -1111,25 +1197,67 @@ BATTERY_TEMPLATE_SENSOR_DESCRIPTIONS: tuple[BatteryTemplateEntityDescription, ..
 )
 
 
-async def create_sun2000_entities(ucs: HuaweiSolarInverterData) -> list[SensorEntity]:
+async def create_sun2000_entities(
+    ucs: HuaweiSolarInverterData, options: Mapping[str, Any]
+) -> list[SensorEntity]:
     """Create SUN2000 sensor entities."""
     entities_to_add: list[SensorEntity] = []
+    split_power_polling = _get_split_power_polling(options)
+    update_timeout = _get_seconds_option(options, CONF_UPDATE_TIMEOUT, UPDATE_TIMEOUT)
+
+    realtime_update_coordinator = ucs.update_coordinator
+    monitoring_update_coordinator = ucs.update_coordinator
+    if split_power_polling:
+        realtime_update_coordinator = HuaweiSolarUpdateCoordinator(
+            ucs.update_coordinator.hass,
+            _LOGGER,
+            device=ucs.device,
+            name=f"{ucs.device.serial_number}_realtime_power_update_coordinator",
+            update_interval=_get_seconds_option(
+                options,
+                CONF_REALTIME_POWER_UPDATE_INTERVAL,
+                REALTIME_POWER_UPDATE_INTERVAL,
+            ),
+            update_timeout=update_timeout,
+        )
+        monitoring_update_coordinator = HuaweiSolarUpdateCoordinator(
+            ucs.update_coordinator.hass,
+            _LOGGER,
+            device=ucs.device,
+            name=f"{ucs.device.serial_number}_monitoring_update_coordinator",
+            update_interval=_get_seconds_option(
+                options, CONF_MONITORING_UPDATE_INTERVAL, MONITORING_UPDATE_INTERVAL
+            ),
+            update_timeout=update_timeout,
+        )
 
     entities_to_add.extend(
         HuaweiSolarSensorEntity(
-            ucs.update_coordinator,
+            _select_sun2000_coordinator(
+                entity_description,
+                realtime_update_coordinator,
+                monitoring_update_coordinator,
+                ucs.update_coordinator,
+                REALTIME_INVERTER_REGISTERS,
+            ),
             entity_description,
             ucs.device_info,
         )
         for entity_description in INVERTER_SENSOR_DESCRIPTIONS
     )
     entities_to_add.append(
-        HuaweiSolarAlarmSensorEntity(ucs.update_coordinator, ucs.device_info)
+        HuaweiSolarAlarmSensorEntity(monitoring_update_coordinator, ucs.device_info)
     )
 
     entities_to_add.extend(
         HuaweiSolarSensorEntity(
-            ucs.update_coordinator,
+            _select_sun2000_coordinator(
+                entity_description,
+                realtime_update_coordinator,
+                monitoring_update_coordinator,
+                ucs.update_coordinator,
+                REALTIME_INVERTER_REGISTERS,
+            ),
             entity_description,
             ucs.device_info,
         )
@@ -1149,9 +1277,31 @@ async def create_sun2000_entities(ucs: HuaweiSolarInverterData) -> list[SensorEn
     if ucs.device.power_meter_type == rv.MeterType.SINGLE_PHASE:
         assert ucs.power_meter_update_coordinator
         assert ucs.power_meter
+        power_meter_realtime_update_coordinator = ucs.power_meter_update_coordinator
+        if split_power_polling:
+            power_meter_realtime_update_coordinator = HuaweiSolarUpdateCoordinator(
+                ucs.power_meter_update_coordinator.hass,
+                _LOGGER,
+                device=ucs.device,
+                name=f"{ucs.device.serial_number}_power_meter_realtime_power_update_coordinator",
+                update_interval=_get_seconds_option(
+                    options,
+                    CONF_REALTIME_POWER_UPDATE_INTERVAL,
+                    REALTIME_POWER_UPDATE_INTERVAL,
+                ),
+                update_timeout=update_timeout,
+            )
         entities_to_add.extend(
             HuaweiSolarSensorEntity(
-                ucs.power_meter_update_coordinator, entity_description, ucs.power_meter
+                _select_sun2000_coordinator(
+                    entity_description,
+                    power_meter_realtime_update_coordinator,
+                    monitoring_update_coordinator,
+                    ucs.power_meter_update_coordinator,
+                    REALTIME_POWER_METER_REGISTERS,
+                ),
+                entity_description,
+                ucs.power_meter,
             )
             for entity_description in SINGLE_PHASE_METER_ENTITY_DESCRIPTIONS
         )
@@ -1159,9 +1309,31 @@ async def create_sun2000_entities(ucs: HuaweiSolarInverterData) -> list[SensorEn
     elif ucs.device.power_meter_type == rv.MeterType.THREE_PHASE:
         assert ucs.power_meter_update_coordinator
         assert ucs.power_meter
+        power_meter_realtime_update_coordinator = ucs.power_meter_update_coordinator
+        if split_power_polling:
+            power_meter_realtime_update_coordinator = HuaweiSolarUpdateCoordinator(
+                ucs.power_meter_update_coordinator.hass,
+                _LOGGER,
+                device=ucs.device,
+                name=f"{ucs.device.serial_number}_power_meter_realtime_power_update_coordinator",
+                update_interval=_get_seconds_option(
+                    options,
+                    CONF_REALTIME_POWER_UPDATE_INTERVAL,
+                    REALTIME_POWER_UPDATE_INTERVAL,
+                ),
+                update_timeout=update_timeout,
+            )
         entities_to_add.extend(
             HuaweiSolarSensorEntity(
-                ucs.power_meter_update_coordinator, entity_description, ucs.power_meter
+                _select_sun2000_coordinator(
+                    entity_description,
+                    power_meter_realtime_update_coordinator,
+                    monitoring_update_coordinator,
+                    ucs.power_meter_update_coordinator,
+                    REALTIME_POWER_METER_REGISTERS,
+                ),
+                entity_description,
+                ucs.power_meter,
             )
             for entity_description in THREE_PHASE_METER_ENTITY_DESCRIPTIONS
         )
@@ -1182,10 +1354,32 @@ async def create_sun2000_entities(ucs: HuaweiSolarInverterData) -> list[SensorEn
     if ucs.device.battery_type != rv.StorageProductModel.NONE:
         assert ucs.energy_storage_update_coordinator
         assert ucs.connected_energy_storage
+        energy_storage_realtime_update_coordinator = (
+            ucs.energy_storage_update_coordinator
+        )
+        if split_power_polling:
+            energy_storage_realtime_update_coordinator = HuaweiSolarUpdateCoordinator(
+                ucs.energy_storage_update_coordinator.hass,
+                _LOGGER,
+                device=ucs.device,
+                name=f"{ucs.device.serial_number}_energy_storage_realtime_power_update_coordinator",
+                update_interval=_get_seconds_option(
+                    options,
+                    CONF_REALTIME_POWER_UPDATE_INTERVAL,
+                    REALTIME_POWER_UPDATE_INTERVAL,
+                ),
+                update_timeout=update_timeout,
+            )
 
         entities_to_add.extend(
             HuaweiSolarSensorEntity(
-                ucs.energy_storage_update_coordinator,
+                _select_sun2000_coordinator(
+                    entity_description,
+                    energy_storage_realtime_update_coordinator,
+                    monitoring_update_coordinator,
+                    ucs.energy_storage_update_coordinator,
+                    REALTIME_ENERGY_STORAGE_REGISTERS,
+                ),
                 entity_description,
                 ucs.connected_energy_storage,
             )
@@ -2008,14 +2202,39 @@ def create_charger_entities(
 
 
 def create_sdongle_entities(
+    hass: HomeAssistant,
     ucs: HuaweiSolarDeviceData,
+    options: Mapping[str, Any],
 ) -> list["HuaweiSolarSensorEntity"]:
     """Create SDongle sensor entities."""
     assert isinstance(ucs.device, SDongleDevice)
+    realtime_update_coordinator = ucs.update_coordinator
+    if _get_split_power_polling(options):
+        realtime_update_coordinator = HuaweiSolarUpdateCoordinator(
+            hass,
+            _LOGGER,
+            device=ucs.device,
+            name=f"{ucs.device.serial_number}_realtime_power_update_coordinator",
+            update_interval=_get_seconds_option(
+                options,
+                CONF_REALTIME_POWER_UPDATE_INTERVAL,
+                REALTIME_POWER_UPDATE_INTERVAL,
+            ),
+            update_timeout=_get_seconds_option(
+                options, CONF_UPDATE_TIMEOUT, UPDATE_TIMEOUT
+            ),
+        )
 
     return [
         HuaweiSolarSensorEntity(
-            ucs.update_coordinator, entity_description, ucs.device_info
+            (
+                realtime_update_coordinator
+                if _register_name_from_key(entity_description.key)
+                in REALTIME_SDONGLE_REGISTERS
+                else ucs.update_coordinator
+            ),
+            entity_description,
+            ucs.device_info,
         )
         for entity_description in SDONGLE_SENSOR_DESCRIPTIONS
     ]
@@ -2214,13 +2433,13 @@ async def async_setup_entry(
     entities_to_add = []
     for ucs in device_datas:
         if isinstance(ucs, HuaweiSolarInverterData):
-            entities_to_add.extend(await create_sun2000_entities(ucs))
+            entities_to_add.extend(await create_sun2000_entities(ucs, entry.options))
         elif isinstance(ucs.device, EMMADevice):
             entities_to_add.extend(create_emma_entities(ucs))
         elif isinstance(ucs.device, SChargerDevice):
             entities_to_add.extend(create_charger_entities(ucs))
         elif isinstance(ucs.device, SDongleDevice):
-            entities_to_add.extend(create_sdongle_entities(ucs))
+            entities_to_add.extend(create_sdongle_entities(hass, ucs, entry.options))
         elif isinstance(ucs.device, MeterDevice):
             entities_to_add.extend(create_meter_entities(ucs))
         elif isinstance(ucs.device, SmartLoggerDevice):

--- a/sensor.py
+++ b/sensor.py
@@ -2445,7 +2445,10 @@ async def async_setup_entry(
         elif isinstance(ucs.device, SmartLoggerDevice):
             entities_to_add.extend(create_smartlogger_entities(ucs))
 
-    async_add_entities(entities_to_add, True)
+    async_add_entities(
+        entities_to_add,
+        not _get_split_power_polling(entry.options),
+    )
 
 
 class HuaweiSolarSensorEntity(

--- a/strings.json
+++ b/strings.json
@@ -108,6 +108,24 @@
             }
         }
     },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "tcp_timeout": "TCP request timeout (seconds)",
+                    "wait_between_requests": "Minimum wait between requests (seconds)",
+                    "update_timeout": "Coordinator update timeout (seconds)",
+                    "split_power_polling": "Use separate fast polling for power sensors",
+                    "realtime_power_update_interval": "Power sensor update interval (seconds)",
+                    "monitoring_update_interval": "Status and alarm update interval (seconds)",
+                    "inverter_update_interval": "Inverter background update interval (seconds)",
+                    "power_meter_update_interval": "Power meter background update interval (seconds)",
+                    "energy_storage_update_interval": "Energy storage background update interval (seconds)"
+                },
+                "description": "Tune Modbus request timing and polling intervals. Defaults match the integration's standard behavior."
+            }
+        }
+    },
     "device": {
         "battery_1": {
             "name": "Battery 1"


### PR DESCRIPTION
I ran into this issue of entities showing "Unavailable" in my setup of 2 inverters in cascade which has been discussed here: https://github.com/wlcrs/huawei_solar/discussions/1035

After trying all of the mentioned suggestions (including new wiring both for rs485 and FE) I still had the issue. Investigating in the logs, I realized that the integration times out requests after 10 seconds. However, I noticed that my device was actually answering some of the queried registers even after 13/14 seconds. These registers timing out are actually (at least in my setup) mostly static registers (e.g., inverter error codes).

So this PR fixes my setup by having an explicit setting for the TCP timeout, but also by segregating the registers into a sort of classification that makes sense to me. E.g, I'm now able to poll the kind of registers that change often (e.g., power related) at a rate of 10s without any issues, while some of the registers I put a much slower polling rate due to their slow-changing nature.

I understand that you've mentioned that for custom polling you recommend setting up an automation, so take this PR as a sort of inspiration if you wish. I think being able to have a more relaxed setting for the TCP timeout makes sense to many users with the "slow" dongle and a cascaded setup with recent firmware versions.

Thank you for your awesome work with this integration :)