### PR TITLE
Avoid write-permission probe when parameter configuration is disabled

### DIFF
--- a/sensor.py
+++ b/sensor.py
@@ -1168,8 +1168,8 @@ async def create_sun2000_entities(ucs: HuaweiSolarInverterData) -> list[SensorEn
 
     if (
         not isinstance(ucs.device.primary_device, (EMMADevice, SmartLoggerDevice))
-        and await ucs.device.has_write_permission()
         and ucs.configuration_update_coordinator
+        and await ucs.device.has_write_permission()
     ):
         entities_to_add.append(
             HuaweiSolarActivePowerControlModeEntity(


### PR DESCRIPTION
### Summary

Avoid calling `has_write_permission()` while creating sensor entities when parameter configuration is disabled.

### Why

`configuration_update_coordinator` is only created when parameter configuration is enabled. The optional `HuaweiSolarActivePowerControlModeEntity` cannot be added without that coordinator, but the current condition evaluates `await ucs.device.has_write_permission()` before checking the coordinator.

That write-permission probe performs a write test register operation. If that write test fails or interrupts the Modbus connection, the whole sensor platform setup can fail even though the installation is configured read-only.

### Change

Reorder the condition so `ucs.configuration_update_coordinator` is checked before `await ucs.device.has_write_permission()`.

This preserves behavior when parameter configuration is enabled, while avoiding an unnecessary write probe when it is disabled.

### Verification

- Ran `python3 -m py_compile sensor.py`.
- Applied the same one-line change locally on a `2.1.1` Home Assistant installation where `enable_parameter_configuration: false`.
- Before the change, `huawei_solar.sensor` failed during setup at `has_write_permission()` and inverter/power-meter sensor entities stayed unavailable/restored.
- After the change and HA restart, the entities were created and populated values such as active power, input power, total yield, daily yield, and meter consumption/export.

Fixes #1364
