### PR TITLE
Improve reliability for multi-inverter cascade setups

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,5 +1,6 @@
 """The Huawei Solar integration."""
 
+import asyncio
 import logging
 
 from homeassistant.config_entries import ConfigEntry
@@ -45,6 +46,7 @@ from .const import (
     INVERTER_UPDATE_INTERVAL,
     OPTIMIZER_UPDATE_INTERVAL,
     POWER_METER_UPDATE_INTERVAL,
+    SUB_DEVICE_STAGGER_DELAY,
 )
 from .services import async_setup_services
 from .types import (
@@ -215,7 +217,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: HuaweiSolarConfigEntry) 
 
         device_datas: list[HuaweiSolarDeviceData] = [primary_device_data]
 
-        for extra_unit_id in entry.data[CONF_SLAVE_IDS][1:]:
+        for sub_index, extra_unit_id in enumerate(entry.data[CONF_SLAVE_IDS][1:]):
+            if sub_index > 0:
+                await asyncio.sleep(SUB_DEVICE_STAGGER_DELAY.total_seconds())
+
             sub_device = await create_sub_device_instance(primary_device, extra_unit_id)
             sub_device_data = await _setup_device_data(hass, entry, sub_device)
 

--- a/const.py
+++ b/const.py
@@ -19,6 +19,12 @@ INVERTER_UPDATE_INTERVAL = timedelta(seconds=30)
 POWER_METER_UPDATE_INTERVAL = timedelta(seconds=30)
 ENERGY_STORAGE_UPDATE_INTERVAL = timedelta(seconds=30)
 UPDATE_TIMEOUT = timedelta(seconds=29)
+
+# retry transient errors (timeouts, device-busy) a few times before failing
+MAX_UPDATE_RETRIES = 2
+RETRY_DELAY_BETWEEN_ATTEMPTS = timedelta(seconds=2)
+# stagger sub-device setup in cascades to reduce Modbus bus contention
+SUB_DEVICE_STAGGER_DELAY = timedelta(seconds=5)
 # configuration can only change when edited through FusionSolar web or app
 CONFIGURATION_UPDATE_INTERVAL = timedelta(minutes=15)
 CONFIGURATION_UPDATE_TIMEOUT = timedelta(minutes=1)

--- a/update_coordinator.py
+++ b/update_coordinator.py
@@ -24,7 +24,12 @@ from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import OPTIMIZER_UPDATE_TIMEOUT, UPDATE_TIMEOUT
+from .const import (
+    MAX_UPDATE_RETRIES,
+    OPTIMIZER_UPDATE_TIMEOUT,
+    RETRY_DELAY_BETWEEN_ATTEMPTS,
+    UPDATE_TIMEOUT,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -47,6 +52,8 @@ class HuaweiSolarUpdateCoordinator(
         | None = None,
         request_refresh_debouncer: Debouncer | None = None,
         update_timeout: timedelta = UPDATE_TIMEOUT,
+        max_retries: int = MAX_UPDATE_RETRIES,
+        retry_delay: float = RETRY_DELAY_BETWEEN_ATTEMPTS.total_seconds(),
     ) -> None:
         """Create a HuaweiSolarUpdateCoordinator."""
         super().__init__(
@@ -59,49 +66,106 @@ class HuaweiSolarUpdateCoordinator(
         )
         self.device = device
         self.update_timeout = update_timeout
+        self._max_retries = max_retries
+        self._retry_delay = retry_delay
+
+    _RETRYABLE_EXCEPTION_CODES = frozenset({
+        0x04,  # SERVER_DEVICE_FAILURE
+        0x05,  # ACKNOWLEDGE
+        0x06,  # SERVER_DEVICE_BUSY
+    })
 
     async def _async_update_data(self) -> dict[RegisterName, Result[Any]]:
         register_names_set = set(
             chain.from_iterable(ctx["register_names"] for ctx in self.async_contexts())
         )
-        try:
-            async with asyncio.timeout(self.update_timeout.total_seconds()):
-                return await self.device.batch_update(list(register_names_set))
-        except TimeoutError as err:
-            raise UpdateFailed(
-                f"Timeout communicating with {self.device.serial_number}: "
-                "the device did not respond in time"
-            ) from err
-        except ReadException as err:
-            if err.modbus_exception_code == 0x02:  # ILLEGAL_DATA_ADDRESS
-                _LOGGER.error(
-                    "Device %s reported an illegal address error during a batch update. "
-                    "This likely means the library is querying a register that is not "
-                    "supported by your specific device. "
-                    "To find the culprit: systematically disable sensors one by one in "
-                    "Home Assistant, wait at least 30 seconds after each change, and "
-                    "check whether the error disappears. Please report the offending "
-                    "sensor to the integration maintainers.",
+        register_names_list = list(register_names_set)
+
+        for attempt in range(self._max_retries + 1):
+            try:
+                async with asyncio.timeout(self.update_timeout.total_seconds()):
+                    return await self.device.batch_update(register_names_list)
+            except TimeoutError as err:
+                if attempt < self._max_retries:
+                    _LOGGER.debug(
+                        "Timeout updating %s (attempt %d/%d). "
+                        "This is common in cascade setups where coordinators share "
+                        "a Modbus connection. Retrying in %.1fs",
+                        self.device.serial_number,
+                        attempt + 1,
+                        self._max_retries + 1,
+                        self._retry_delay,
+                    )
+                    await asyncio.sleep(self._retry_delay)
+                    continue
+                raise UpdateFailed(
+                    f"Timeout communicating with {self.device.serial_number}: "
+                    "the device did not respond in time after "
+                    f"{self._max_retries + 1} attempts"
+                ) from err
+            except ReadException as err:
+                if (
+                    err.modbus_exception_code in self._RETRYABLE_EXCEPTION_CODES
+                    and attempt < self._max_retries
+                ):
+                    _LOGGER.debug(
+                        "Device %s returned transient Modbus exception 0x%02x "
+                        "during batch update (attempt %d/%d). Retrying in %.1fs",
+                        self.device.serial_number,
+                        err.modbus_exception_code,
+                        attempt + 1,
+                        self._max_retries + 1,
+                        self._retry_delay,
+                    )
+                    await asyncio.sleep(self._retry_delay)
+                    continue
+
+                if err.modbus_exception_code == 0x02:  # ILLEGAL_DATA_ADDRESS
+                    _LOGGER.error(
+                        "Device %s reported an illegal address error during a batch update. "
+                        "This likely means the library is querying a register that is not "
+                        "supported by your specific device. "
+                        "To find the culprit: systematically disable sensors one by one in "
+                        "Home Assistant, wait at least 30 seconds after each change, and "
+                        "check whether the error disappears. Please report the offending "
+                        "sensor to the integration maintainers.",
+                        self.device.serial_number,
+                    )
+                raise UpdateFailed(
+                    f"Could not update {self.device.serial_number} values: {err}"
+                ) from err
+            except ConnectionInterruptedException as err:
+                if attempt < self._max_retries:
+                    _LOGGER.debug(
+                        "Connection to %s was interrupted during update "
+                        "(attempt %d/%d). Retrying in %.1fs",
+                        self.device.serial_number,
+                        attempt + 1,
+                        self._max_retries + 1,
+                        self._retry_delay,
+                    )
+                    await asyncio.sleep(self._retry_delay)
+                    continue
+                _LOGGER.warning(
+                    "Connection to %s was interrupted during update. "
+                    "The inverter only supports one Modbus connection at a time - "
+                    "check whether another device has connected to the inverter",
                     self.device.serial_number,
                 )
-            raise UpdateFailed(
-                f"Could not update {self.device.serial_number} values: {err}"
-            ) from err
-        except ConnectionInterruptedException as err:
-            _LOGGER.warning(
-                "Connection to %s was interrupted during update. "
-                "The inverter only supports one Modbus connection at a time - "
-                "check whether another device has connected to the inverter",
-                self.device.serial_number,
-            )
-            raise UpdateFailed(
-                f"Connection to {self.device.serial_number} was interrupted, probably by another device. "
-                "The inverter only supports one Modbus connection at a time."
-            ) from err
-        except HuaweiSolarException as err:
-            raise UpdateFailed(
-                f"Could not update {self.device.serial_number} values: {err}"
-            ) from err
+                raise UpdateFailed(
+                    f"Connection to {self.device.serial_number} was interrupted, probably by another device. "
+                    "The inverter only supports one Modbus connection at a time."
+                ) from err
+            except HuaweiSolarException as err:
+                raise UpdateFailed(
+                    f"Could not update {self.device.serial_number} values: {err}"
+                ) from err
+
+        # Should not be reached, but satisfies the type checker
+        raise UpdateFailed(
+            f"Could not update {self.device.serial_number} values after "
+            f"{self._max_retries + 1} attempts"
+        )
 
 
 class HuaweiSolarOptimizerUpdateCoordinator(


### PR DESCRIPTION
### Summary

Retry transient Modbus errors and stagger sub-device setup so entities stay available in multi-inverter cascade setups.

### Why

In a cascade, every inverter, battery and power meter gets its own `HuaweiSolarUpdateCoordinator`, but they all share one Modbus connection. Two things keep making entities go unavailable:

1. **No retry on transient errors.** A single `TimeoutError`, `ServerDeviceBusy` (0x06) or `ServerDeviceFailure` (0x04) immediately raises `UpdateFailed` and knocks out every entity on that coordinator. On a shared bus these responses are perfectly normal — the device is just busy, not broken.

2. **All coordinators fire at once.** During setup, every sub-device coordinator starts its first refresh at the same time. They pile up on the shared `update_lock`, the 29s timeout starts ticking while waiting, and you get premature timeouts.

This is what users are hitting in #1373 (3-inverter cascade) and #1376 (shared bus with EMMA).

I'm running this setup myself: 2x SUN2000-8KTL-M1 in cascade via SDongle, DTSU power meter, LUNA2000 battery. That's up to 8 coordinators sharing one Modbus connection through the SDongle. Entities regularly go unavailable during the day — much better at night.

### Changes

**`update_coordinator.py`** — retry `batch_update` up to 2 times on `TimeoutError`, `ConnectionInterruptedException` and transient Modbus exceptions (0x04, 0x05, 0x06) before raising `UpdateFailed`. 2-second pause between attempts. Permanent errors like `ILLEGAL_DATA_ADDRESS` (0x02) still fail immediately.

**`__init__.py`** — stagger sub-device creation by 5 seconds so coordinators don't all poll simultaneously.

**`const.py`** — new constants: `MAX_UPDATE_RETRIES`, `RETRY_DELAY_BETWEEN_ATTEMPTS`, `SUB_DEVICE_STAGGER_DELAY`.

Related: #1373, #1376