### PR TITLE
Do not clamp EMMA maximum feed grid power to one inverter rated power

### DIFF
--- a/number.py
+++ b/number.py
@@ -118,7 +118,14 @@ EMMA_NUMBER_DESCRIPTIONS: tuple[HuaweiSolarNumberEntityDescription, ...] = (
     ),
     HuaweiSolarNumberEntityDescription(
         key=rn.EMMA_MAXIMUM_FEED_GRID_POWER_WATT,
-        static_maximum_key=rn.INVERTER_RATED_POWER,
+        # rn.INVERTER_RATED_POWER (EMMA register 30362) only reports the rated
+        # power of a single inverter, not the capacity of the whole plant. When
+        # the EMMA manages multiple inverters, using it as maximum under-clamps
+        # this entity: an EMMA-A02 managing a 6kW + 3.3kW inverter reports
+        # 6000W, making the real 9.3kW feed-in limit impossible to configure.
+        # Use a fixed upper bound instead, like
+        # EMMA_TOU_MAXIMUM_POWER_FOR_CHARGING_BATTERIES_FROM_GRID below.
+        native_max_value=50000,
         native_step=1,
         native_min_value=-1000,
         icon="mdi:transmission-tower-off",

--- a/number.py
+++ b/number.py
@@ -118,13 +118,6 @@ EMMA_NUMBER_DESCRIPTIONS: tuple[HuaweiSolarNumberEntityDescription, ...] = (
     ),
     HuaweiSolarNumberEntityDescription(
         key=rn.EMMA_MAXIMUM_FEED_GRID_POWER_WATT,
-        # rn.INVERTER_RATED_POWER (EMMA register 30362) only reports the rated
-        # power of a single inverter, not the capacity of the whole plant. When
-        # the EMMA manages multiple inverters, using it as maximum under-clamps
-        # this entity: an EMMA-A02 managing a 6kW + 3.3kW inverter reports
-        # 6000W, making the real 9.3kW feed-in limit impossible to configure.
-        # Use a fixed upper bound instead, like
-        # EMMA_TOU_MAXIMUM_POWER_FOR_CHARGING_BATTERIES_FROM_GRID below.
         native_max_value=50000,
         native_step=1,
         native_min_value=-1000,


### PR DESCRIPTION
The EMMA_MAXIMUM_FEED_GRID_POWER_WATT entity took its maximum from rn.INVERTER_RATED_POWER (EMMA register 30362), which only reports the rated power of a single inverter, not the capacity of the whole plant.

On installations where the EMMA manages multiple inverters this clamps the entity far below the real limit: an EMMA-A02 managing a 6kW + 3.3kW inverter reports 6000W, so the actual 9.3kW feed-in limit cannot be configured from Home Assistant.

Use a fixed native_max_value instead, matching the approach already used by EMMA_TOU_MAXIMUM_POWER_FOR_CHARGING_BATTERIES_FROM_GRID in the same tuple.

# Proposed Changes

> (Describe the changes and rationale behind them)

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/

- type: checkboxes
  id: checks
  attributes:
    label: "Please confirm the following:"
    options:
      - label: I'm following the [AI Policy](../AI_POLICY.md).