### PR TITLE
Use configuration timeout for configuration coordinators

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -39,6 +39,7 @@ from .const import (
     CONF_ENABLE_PARAMETER_CONFIGURATION,
     CONF_SLAVE_IDS,
     CONFIGURATION_UPDATE_INTERVAL,
+    CONFIGURATION_UPDATE_TIMEOUT,
     DATA_DEVICE_DATAS,
     DOMAIN,
     ENERGY_STORAGE_UPDATE_INTERVAL,
@@ -492,6 +493,7 @@ async def _setup_inverter_device_data(
             device=device,
             name=f"{device.serial_number}_config_data_update_coordinator",
             update_interval=CONFIGURATION_UPDATE_INTERVAL,
+            update_timeout=CONFIGURATION_UPDATE_TIMEOUT,
         )
     else:
         configuration_update_coordinator = None
@@ -575,6 +577,7 @@ async def _setup_device_data(
             device=device,
             name=f"{device.serial_number}_config_data_update_coordinator",
             update_interval=CONFIGURATION_UPDATE_INTERVAL,
+            update_timeout=CONFIGURATION_UPDATE_TIMEOUT,
         )
     else:
         configuration_update_coordinator = None


### PR DESCRIPTION
# Proposed Changes

The two configuration-data update coordinators were still using the shared 29-second telemetry timeout, even though a dedicated 60-second `CONFIGURATION_UPDATE_TIMEOUT` already existed in `const.py`.

This PR passes that existing timeout to both configuration-coordinator constructors.
Normal telemetry coordinators remain unchanged and keep the 29-second default.

I verified the change on a live two-inverter installation with controlled 24-hour baseline and candidate runs.
With the inherited 29-second timeout, the large configuration coordinator had one failed refresh followed by about 15 minutes of unavailable configuration entities.
With the 60-second timeout, both configuration coordinators completed 202 refreshes without a failure.
Normal telemetry remained within the pre-registered safety limits, with a longest observed outage of 49 seconds.

This change does not address the underlying Modbus or transport instability.
It only gives the slower configuration-read path the timeout that was already defined for it.

## Related Issues

Fixes #1405

**Please confirm the following:**

- [X] I'm following the [AI Policy](https://github.com/wlcrs/huawei_solar/blob/main/AI_POLICY.md).
